### PR TITLE
feat: add prometheus scraper trigger schedule

### DIFF
--- a/efbar/README.md
+++ b/efbar/README.md
@@ -1,0 +1,39 @@
+## Python Plugins for Processing Engine
+
+This Schedule plugin is made for scraping Prometheus endpoint and write metrics back to influxdb3.
+
+It needs just a couple of `import`s:
+
+```bash
+$ influxdb3 install package requests
+$ influxdb3 install package prometheus_client
+```
+
+After you've created a DB for the trigger with:
+
+```bash
+$ influxdb3 create database metrics
+```
+
+You could then create the trigger:
+
+```bash
+influxdb3 create trigger --trigger-spec "every:10s" --plugin-filename <path_to_file>/prometheus_metrics.py --database metrics --trigger-arguments "hostname=localhost,ip_address=100.100.100.100,port=80" tailscale-localhost-metrics
+```
+
+In the above example, it creates a schedule trigger that scrapes your local Tailscaled service (more here https://tailscale.com/kb/1482/client-metrics) such that you can have:
+
+```bash
+➜ influxdb3 query --database=metrics "SELECT path,value,time FROM tailscaled_inbound_bytes_total WHERE host='localhost' AND path='derp' ORDER BY time ASC"
++------+-----------+-------------------------------+
+| path | value     | time                          |
++------+-----------+-------------------------------+
+| derp | 2681308.0 | 2025-02-24T09:35:50.027185292 |
+| derp | 2688844.0 | 2025-02-24T09:36:00.027418810 |
+| derp | 2696380.0 | 2025-02-24T09:36:10.016980230 |
+| derp | 2703916.0 | 2025-02-24T09:36:20.018751834 |
+| derp | 2711452.0 | 2025-02-24T09:36:30.021800981 |
+| derp | 2719324.0 | 2025-02-24T09:36:40.023237792 |
++------+-----------+-------------------------------+
+```
+

--- a/efbar/schedule/prometheus_metrics/prometheus_metrics.py
+++ b/efbar/schedule/prometheus_metrics/prometheus_metrics.py
@@ -1,0 +1,51 @@
+import ast
+import requests
+from prometheus_client.parser import text_string_to_metric_families
+
+
+# Build LP from Prometheus data
+def collect_metrics(influxdb3_local, hostname, ip_address, port, path):
+  try:
+    node_url = "http://%s:%s%s" % (ip_address, port, path)
+    response = requests.get(node_url, timeout=5)
+  except requests.exceptions.RequestException as err:
+    raise SystemExit(err)
+
+  data = response.text
+  for family in text_string_to_metric_families(data):
+    for sample in family.samples:
+
+      name = '{0}'.format(*sample)
+      tag = '{1}'.format(*sample)
+      value = float('{2}'.format(*sample))
+
+      tag_dict = ast.literal_eval(tag)
+
+      line = LineBuilder(name)\
+          .tag("host", hostname)
+
+      if tag_dict:
+        for k,v in tag_dict.items():
+          line.tag(k, v)
+
+      line.float64_field("value", value)
+
+      influxdb3_local.write(line)
+
+  return
+
+
+def process_scheduled_call(influxdb3_local, time, args=None):
+  try:
+      # Set defaults or get from args
+      hostname = args.get("hostname", "localhost") if args else "localhost"
+      ip_address = args.get("ip_address", "127.0.0.1") if args else "127.0.0.1"
+      port = args.get("port", "80") if args else "80"
+      path = args.get("path", "/metrics") if args else "/metrics"
+
+      collect_metrics(influxdb3_local, hostname, ip_address, port, path)
+      influxdb3_local.info(f"Successfully collected metrics for host: {hostname}")
+
+  except Exception as e:
+      influxdb3_local.error(f"Error collecting system metrics: {str(e)}")
+

--- a/efbar/schedule/prometheus_metrics/prometheus_metrics.py
+++ b/efbar/schedule/prometheus_metrics/prometheus_metrics.py
@@ -17,8 +17,12 @@ def collect_metrics(influxdb3_local, hostname, ip_address, port, path):
 
       name = '{0}'.format(*sample)
       tag = '{1}'.format(*sample)
-      value = float('{2}'.format(*sample))
+      val = '{2}'.format(*sample)
 
+      if val in ['nan','NaN','+inf','+Inf','-inf','-Inf']:
+        continue
+
+      value = float(val)
       tag_dict = ast.literal_eval(tag)
 
       line = LineBuilder(name)\


### PR DESCRIPTION
This PR adds a schedule trigger for scraping metrics from and endpoint that exposes a Prometheus metrics.

It only needs a couple of Python libs to be imported: `requests` and `prometheus_client`. 