### PR TITLE
Move System Metrics into Main InfluxData Section

### DIFF
--- a/influxdata/system_metrics/README.md
+++ b/influxdata/system_metrics/README.md
@@ -1,0 +1,185 @@
+# System Metrics Plugin
+
+A comprehensive system monitoring plugin that collects CPU, memory, disk, and network metrics from the host system. This plugin provides detailed performance insights including per-core CPU statistics, memory usage breakdowns, disk I/O performance, and network interface statistics.
+
+## Prerequisites
+
+- InfluxDB 3.0+
+- Python psutil library (for system metrics collection)
+
+## Files
+
+- `system_metrics.py`: Main plugin file containing metric collection logic
+- `system_metrics_config_scheduler.toml`: Configuration template for scheduled triggers
+- `README.md`: This documentation file
+
+## Features
+
+- **CPU Metrics**: Overall and per-core CPU usage, frequency, load averages, context switches, and interrupts
+- **Memory Metrics**: RAM usage, swap statistics, and memory page fault information  
+- **Disk Metrics**: Partition usage, I/O statistics, throughput, IOPS, and latency calculations
+- **Network Metrics**: Interface statistics including bytes/packets sent/received and error counts
+- **Configurable Collection**: Enable/disable specific metric types via configuration
+- **Robust Error Handling**: Retry logic and graceful handling of permission errors
+- **Task Tracking**: UUID-based task identification for debugging and log correlation
+
+## Logging
+
+Logs are stored in the `_internal` database (or the database where the trigger is created) in the `system.processing_engine_logs` table. To view logs, use the following query:
+
+```bash
+influxdb3 query --database _internal "SELECT * FROM system.processing_engine_logs"
+```
+
+### Log Columns Description
+- **event_time**: Timestamp of the log event.
+- **trigger_name**: Name of the trigger that generated the log.
+- **log_level**: Severity level (`INFO`, `WARN`, `ERROR`).
+- **log_text**: Message describing the action or error.
+
+## Setup & Run
+
+1. **Copy plugin files to your plugin directory**:
+   ```bash
+   cp system_metrics.py $PLUGIN_DIR/
+   cp system_metrics_config_scheduler.toml $PLUGIN_DIR/
+   ```
+
+2. **Install required Python dependencies**:
+   ```bash
+   pip install psutil
+   ```
+
+3. **Configure the plugin** by editing `system_metrics_config_scheduler.toml`:
+   - Set hostname for metric tagging
+   - Enable/disable specific metric types
+   - Configure retry behavior
+
+## Configure & Create Triggers
+
+### Basic Scheduled Trigger
+```bash
+influxdb3 create trigger \
+  --database system_monitoring \
+  --plugin-filename system_metrics.py \
+  --trigger-spec "every:30s" \
+  system_metrics_trigger
+```
+
+### Using Configuration File
+```bash
+influxdb3 create trigger \
+  --database system_monitoring \
+  --plugin-filename system_metrics.py \
+  --trigger-spec "every:1m" \
+  --trigger-arguments config_file_path=system_metrics_config_scheduler.toml \
+  system_metrics_config_trigger
+```
+
+### Custom Configuration
+```bash
+influxdb3 create trigger \
+  --database system_monitoring \
+  --plugin-filename system_metrics.py \
+  --trigger-spec "every:30s" \
+  --trigger-arguments hostname=web-server-01,include_disk=false,max_retries=5 \
+  system_metrics_custom_trigger
+```
+
+## Arguments
+
+| Argument | Example | Description | Required |
+|----------|---------|-------------|----------|
+| `hostname` | `localhost` | Hostname to tag metrics with | No |
+| `include_cpu` | `true` | Include CPU metrics collection | No |
+| `include_memory` | `true` | Include memory metrics collection | No |
+| `include_disk` | `true` | Include disk metrics collection | No |
+| `include_network` | `true` | Include network metrics collection | No |
+| `max_retries` | `3` | Maximum number of retry attempts on failure | No |
+| `config_file_path` | `system_metrics_config_scheduler.toml` | Path to configuration file from PLUGIN_DIR env var | No |
+
+## Measurements and Fields
+
+### system_cpu
+Overall CPU statistics and metrics:
+- **Tags**: `host`, `cpu=total`
+- **Fields**: `user`, `system`, `idle`, `iowait`, `nice`, `irq`, `softirq`, `steal`, `guest`, `guest_nice`, `frequency_current`, `frequency_min`, `frequency_max`, `ctx_switches`, `interrupts`, `soft_interrupts`, `syscalls`, `load1`, `load5`, `load15`
+
+### system_cpu_cores  
+Per-core CPU statistics:
+- **Tags**: `host`, `core` (core number)
+- **Fields**: `usage`, `user`, `system`, `idle`, `iowait`, `nice`, `irq`, `softirq`, `steal`, `guest`, `guest_nice`, `frequency_current`, `frequency_min`, `frequency_max`
+
+### system_memory
+System memory statistics:
+- **Tags**: `host`
+- **Fields**: `total`, `available`, `used`, `free`, `active`, `inactive`, `buffers`, `cached`, `shared`, `slab`, `percent`
+
+### system_swap
+Swap memory statistics:
+- **Tags**: `host`  
+- **Fields**: `total`, `used`, `free`, `percent`, `sin`, `sout`
+
+### system_memory_faults
+Memory page fault information (when available):
+- **Tags**: `host`
+- **Fields**: `page_faults`, `major_faults`, `minor_faults`, `rss`, `vms`, `dirty`, `uss`, `pss`
+
+### system_disk_usage
+Disk partition usage:
+- **Tags**: `host`, `device`, `mountpoint`, `fstype`
+- **Fields**: `total`, `used`, `free`, `percent`
+
+### system_disk_io
+Disk I/O statistics:
+- **Tags**: `host`, `device` 
+- **Fields**: `reads`, `writes`, `read_bytes`, `write_bytes`, `read_time`, `write_time`, `busy_time`, `read_merged_count`, `write_merged_count`
+
+### system_disk_performance
+Calculated disk performance metrics:
+- **Tags**: `host`, `device`
+- **Fields**: `read_bytes_per_sec`, `write_bytes_per_sec`, `read_iops`, `write_iops`, `avg_read_latency_ms`, `avg_write_latency_ms`, `util_percent`
+
+### system_network
+Network interface statistics:
+- **Tags**: `host`, `interface`
+- **Fields**: `bytes_sent`, `bytes_recv`, `packets_sent`, `packets_recv`, `errin`, `errout`, `dropin`, `dropout`
+
+## Usage Examples
+
+### Monitor Web Server Performance
+```bash
+# Create trigger for web server monitoring every 15 seconds
+influxdb3 create trigger \
+  --database web_monitoring \
+  --plugin-filename system_metrics.py \
+  --trigger-spec "every:15s" \
+  --trigger-arguments hostname=web-server-01,include_network=true \
+  web_server_metrics
+```
+
+### Database Server Monitoring
+```bash
+# Focus on CPU and disk metrics for database server
+influxdb3 create trigger \
+  --database db_monitoring \
+  --plugin-filename system_metrics.py \
+  --trigger-spec "every:30s" \
+  --trigger-arguments hostname=db-primary,include_disk=true,include_cpu=true,include_network=false \
+  database_metrics
+```
+
+### High-Frequency System Monitoring
+```bash
+# Collect all metrics every 10 seconds with higher retry tolerance
+influxdb3 create trigger \
+  --database system_monitoring \
+  --plugin-filename system_metrics.py \
+  --trigger-spec "every:10s" \
+  --trigger-arguments hostname=critical-server,max_retries=10 \
+  high_freq_metrics
+```
+
+## Questions/Comments
+
+If you have questions or run into any issues with this plugin, please reach out to the InfluxData support team or open an issue in the plugin repository.

--- a/influxdata/system_metrics/system_metrics.py
+++ b/influxdata/system_metrics/system_metrics.py
@@ -1,9 +1,59 @@
+"""
+{
+    "plugin_type": ["scheduled"],
+    "scheduled_args_config": [
+        {
+            "name": "hostname",
+            "example": "localhost",
+            "description": "Hostname to tag metrics with",
+            "required": false
+        },
+        {
+            "name": "include_cpu",
+            "example": "true",
+            "description": "Include CPU metrics collection",
+            "required": false
+        },
+        {
+            "name": "include_memory",
+            "example": "true", 
+            "description": "Include memory metrics collection",
+            "required": false
+        },
+        {
+            "name": "include_disk",
+            "example": "true",
+            "description": "Include disk metrics collection", 
+            "required": false
+        },
+        {
+            "name": "include_network",
+            "example": "true",
+            "description": "Include network metrics collection",
+            "required": false
+        },
+        {
+            "name": "max_retries",
+            "example": "3",
+            "description": "Maximum number of retry attempts on failure",
+            "required": false
+        },
+        {
+            "name": "config_file_path",
+            "example": "system_metrics_config_scheduler.toml",
+            "description": "Path to configuration file from PLUGIN_DIR env var",
+            "required": false
+        }
+    ]
+}
+"""
+
 import psutil
+import uuid
+import os
+import tomllib
 
-# This was made in a few minutes with Claude in a project with the plugin documentation and 
-# a couple of iterations. It's not perfect, but it's a good starting point for a system metrics plugin.
-
-def collect_cpu_metrics(influxdb3_local, hostname):
+def collect_cpu_metrics(influxdb3_local, hostname, task_id):
     # Get CPU frequencies
     cpu_freq = psutil.cpu_freq(percpu=False)
     cpu_stats = psutil.cpu_stats()
@@ -73,10 +123,10 @@ def collect_cpu_metrics(influxdb3_local, hostname):
             
             influxdb3_local.write(line)
     except Exception as e:
-        influxdb3_local.warn(f"Error collecting per-core CPU metrics: {str(e)}")
+        influxdb3_local.warn(f"[{task_id}] Error collecting per-core CPU metrics: {str(e)}")
 
     
-def collect_memory_metrics(influxdb3_local, hostname):
+def collect_memory_metrics(influxdb3_local, hostname, task_id):
     # Virtual memory metrics
     mem = psutil.virtual_memory()
     swap = psutil.swap_memory()
@@ -125,7 +175,7 @@ def collect_memory_metrics(influxdb3_local, hostname):
     except (psutil.AccessDenied, psutil.Error):
         pass
 
-def collect_disk_metrics(influxdb3_local, hostname):
+def collect_disk_metrics(influxdb3_local, hostname, task_id):
     # Collect disk partition usage metrics
     for partition in psutil.disk_partitions(all=False):
         try:
@@ -175,10 +225,10 @@ def collect_disk_metrics(influxdb3_local, hostname):
                 .float64_field("util_percent", getattr(stats, 'busy_time_percent', 0))
             influxdb3_local.write(line)
     except (psutil.Error, AttributeError) as e:
-        influxdb3_local.warn(f"Error collecting disk I/O metrics: {str(e)}")
+        influxdb3_local.warn(f"[{task_id}] Error collecting disk I/O metrics: {str(e)}")
 
 
-def collect_network_metrics(influxdb3_local, hostname):
+def collect_network_metrics(influxdb3_local, hostname, task_id):
     net_io = psutil.net_io_counters(pernic=True)
     
     for interface, stats in net_io.items():
@@ -196,14 +246,66 @@ def collect_network_metrics(influxdb3_local, hostname):
         influxdb3_local.write(line)
 
 def process_scheduled_call(influxdb3_local, time, args=None):
+    task_id = str(uuid.uuid4())
+    
     try:
-        # Get hostname from args or default to 'localhost'
-        hostname = args.get("hostname", "localhost") if args else "localhost"
+        # Load configuration from TOML file if provided
+        if args and 'config_file_path' in args:
+            plugin_dir = os.environ.get('PLUGIN_DIR')
+            if plugin_dir:
+                config_path = os.path.join(plugin_dir, args['config_file_path'])
+                try:
+                    with open(config_path, 'rb') as f:
+                        config = tomllib.load(f)
+                    # Override args with config values
+                    args.update(config)
+                    influxdb3_local.info(f"[{task_id}] Loaded configuration from {config_path}")
+                except FileNotFoundError:
+                    influxdb3_local.warn(f"[{task_id}] Config file not found: {config_path}")
+                except Exception as e:
+                    influxdb3_local.error(f"[{task_id}] Error loading config file: {e}")
         
-        collect_cpu_metrics(influxdb3_local, hostname)
-        collect_memory_metrics(influxdb3_local, hostname)
-        collect_disk_metrics(influxdb3_local, hostname)
-        collect_network_metrics(influxdb3_local, hostname)
-        influxdb3_local.info(f"Successfully collected system metrics for host: {hostname}")
+        # Set default values if args is None
+        if args is None:
+            args = {}
+        
+        # Get configuration values with defaults
+        hostname = args.get("hostname", "localhost")
+        include_cpu = str(args.get("include_cpu", "true")).lower() == "true"
+        include_memory = str(args.get("include_memory", "true")).lower() == "true"
+        include_disk = str(args.get("include_disk", "true")).lower() == "true"
+        include_network = str(args.get("include_network", "true")).lower() == "true"
+        max_retries = int(args.get("max_retries", 3))
+        
+        influxdb3_local.info(f"[{task_id}] Starting system metrics collection for host: {hostname}")
+        
+        # Collect metrics with retry logic
+        def collect_with_retry(collect_func, metric_type):
+            for attempt in range(max_retries + 1):
+                try:
+                    collect_func(influxdb3_local, hostname, task_id)
+                    break
+                except Exception as e:
+                    if attempt == max_retries:
+                        influxdb3_local.error(f"[{task_id}] Failed to collect {metric_type} metrics after {max_retries} retries: {e}")
+                        raise
+                    influxdb3_local.warn(f"[{task_id}] {metric_type} metrics collection attempt {attempt + 1} failed, retrying: {e}")
+        
+        # Collect enabled metrics
+        if include_cpu:
+            collect_with_retry(collect_cpu_metrics, "CPU")
+        
+        if include_memory:
+            collect_with_retry(collect_memory_metrics, "memory")
+        
+        if include_disk:
+            collect_with_retry(collect_disk_metrics, "disk")
+        
+        if include_network:
+            collect_with_retry(collect_network_metrics, "network")
+        
+        influxdb3_local.info(f"[{task_id}] Successfully collected system metrics for host: {hostname}")
+        
     except Exception as e:
-        influxdb3_local.error(f"Error collecting system metrics: {str(e)}")
+        influxdb3_local.error(f"[{task_id}] Error collecting system metrics: {str(e)}")
+        raise

--- a/influxdata/system_metrics/system_metrics_config_scheduler.toml
+++ b/influxdata/system_metrics/system_metrics_config_scheduler.toml
@@ -2,7 +2,7 @@
 # Copy this file to your PLUGIN_DIR and reference it with `--trigger-arguments config_file_path=system_metrics_config_scheduler.toml`
 
 ########## Required Parameters ##########
-# No required parameters - all have sensible defaults
+# No required parameters
 
 ########## Optional Parameters ##########
 
@@ -20,8 +20,8 @@ max_retries = 3         # Maximum retry attempts on collection failure
 
 ###### Example: Create Trigger Using This Config ######
 # influxdb3 create trigger \
-#   --database system_monitoring \
+#   --database [YOUR_DATABASE] \
 #   --plugin-filename system_metrics.py \
-#   --trigger-spec "every:30s" \
+#   --trigger-spec "every:[DURATION e.g. 1s, 1m, 1h]" \
 #   --trigger-arguments config_file_path=system_metrics_config_scheduler.toml \
 #   system_metrics_trigger

--- a/influxdata/system_metrics/system_metrics_config_scheduler.toml
+++ b/influxdata/system_metrics/system_metrics_config_scheduler.toml
@@ -1,0 +1,27 @@
+# System Metrics Plugin Configuration
+# Copy this file to your PLUGIN_DIR and reference it with `--trigger-arguments config_file_path=system_metrics_config_scheduler.toml`
+
+########## Required Parameters ##########
+# No required parameters - all have sensible defaults
+
+########## Optional Parameters ##########
+
+# Hostname to tag all metrics with
+hostname = "localhost"  # e.g., "web-server-01", "db-primary"
+
+# Control which metric types to collect
+include_cpu = true      # Collect CPU usage, frequency, and per-core metrics
+include_memory = true   # Collect memory and swap usage metrics  
+include_disk = true     # Collect disk usage and I/O performance metrics
+include_network = true  # Collect network interface statistics
+
+# Error handling configuration
+max_retries = 3         # Maximum retry attempts on collection failure
+
+###### Example: Create Trigger Using This Config ######
+# influxdb3 create trigger \
+#   --database system_monitoring \
+#   --plugin-filename system_metrics.py \
+#   --trigger-spec "every:30s" \
+#   --trigger-arguments config_file_path=system_metrics_config_scheduler.toml \
+#   system_metrics_trigger


### PR DESCRIPTION
This updates the System Metrics plugin to use the new configuration information for the Plugin Library and also gives it the InfluxData Approved seal in InfluxDB Explorer.