### PR TITLE
docs: finalize README standardization and fix formatting issues

### DIFF
--- a/influxdata/basic_transformation/README.md
+++ b/influxdata/basic_transformation/README.md
@@ -56,8 +56,7 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 - [basic_transformation_config_scheduler.toml](basic_transformation_config_scheduler.toml) - for scheduled triggers
 - [basic_transformation_config_data_writes.toml](basic_transformation_config_data_writes.toml) - for data write triggers
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ## Data requirements
 

--- a/influxdata/basic_transformation/README.md
+++ b/influxdata/basic_transformation/README.md
@@ -51,12 +51,13 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 *To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
 
-Example TOML configuration files are provided:
+#### Example TOML configurations
 
 - [basic_transformation_config_scheduler.toml](basic_transformation_config_scheduler.toml) - for scheduled triggers
 - [basic_transformation_config_data_writes.toml](basic_transformation_config_data_writes.toml) - for data write triggers
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ## Data requirements
 

--- a/influxdata/downsampler/README.md
+++ b/influxdata/downsampler/README.md
@@ -60,8 +60,7 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 [downsampling_config_scheduler.toml](downsampling_config_scheduler.toml)
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ## Schema management
 

--- a/influxdata/downsampler/README.md
+++ b/influxdata/downsampler/README.md
@@ -56,9 +56,12 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 *To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
 
-Example TOML configuration file provided: [downsampling_config_scheduler.toml](downsampling_config_scheduler.toml)
+#### Example TOML configuration
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+[downsampling_config_scheduler.toml](downsampling_config_scheduler.toml)
+
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ## Schema management
 
@@ -68,12 +71,7 @@ Each downsampled record includes three additional metadata columns:
 - `time_from` — the minimum timestamp among the original points in the interval  
 - `time_to` — the maximum timestamp among the original points in the interval
 
-## Software requirements
-
-- **InfluxDB 3 Core/Enterprise**: with the Processing Engine enabled.
-- **Python packages**: No additional packages required
-
-### Installation steps
+## Installation steps
 
 1. Start InfluxDB 3 with the Processing Engine enabled (`--plugin-dir /path/to/plugins`):
 

--- a/influxdata/forecast_error_evaluator/README.md
+++ b/influxdata/forecast_error_evaluator/README.md
@@ -94,8 +94,7 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 [forecast_error_config_scheduler.toml](forecast_error_config_scheduler.toml)
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ## Software Requirements
 

--- a/influxdata/forecast_error_evaluator/README.md
+++ b/influxdata/forecast_error_evaluator/README.md
@@ -90,9 +90,12 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 *To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
 
-Example TOML configuration file provided: [forecast_error_config_scheduler.toml](forecast_error_config_scheduler.toml)
+#### Example TOML configuration
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+[forecast_error_config_scheduler.toml](forecast_error_config_scheduler.toml)
+
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ## Software Requirements
 
@@ -178,7 +181,7 @@ influxdb3 query \
 
 **Notification example:**
 
- [WARN] Forecast error alert in temp_forecast.predicted: rmse=1.2. Tags: location=station1
+[WARN] Forecast error alert in temp_forecast.predicted: rmse=1.2. Tags: location=station1
 
 ### Example 2: Multi-metric validation with multiple channels
 

--- a/influxdata/influxdb_to_iceberg/README.md
+++ b/influxdata/influxdb_to_iceberg/README.md
@@ -47,8 +47,7 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 [influxdb_to_iceberg_config_scheduler.toml](influxdb_to_iceberg_config_scheduler.toml)
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ### HTTP trigger parameters
 

--- a/influxdata/influxdb_to_iceberg/README.md
+++ b/influxdata/influxdb_to_iceberg/README.md
@@ -43,9 +43,12 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 *To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
 
-Example TOML configuration file provided: [influxdb_to_iceberg_config_scheduler.toml](influxdb_to_iceberg_config_scheduler.toml)
+#### Example TOML configuration
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+[influxdb_to_iceberg_config_scheduler.toml](influxdb_to_iceberg_config_scheduler.toml)
+
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ### HTTP trigger parameters
 
@@ -110,7 +113,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
 - `[sql-sqlite]` for SQL catalog with SQLite
 - See [PyIceberg documentation](https://py.iceberg.apache.org/#installation) for all options
 
-## Data requirements
+## Schema requirement
 
 The plugin assumes that the table schema is already defined in the database, as it relies on this schema to retrieve field and tag names required for processing.
 

--- a/influxdata/mad_check/README.md
+++ b/influxdata/mad_check/README.md
@@ -95,8 +95,7 @@ Multiple thresholds are separated by `@`: `temp:2.5:20:5@load:3:10:2m`
 
 [mad_anomaly_config_data_writes.toml](mad_anomaly_config_data_writes.toml)
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ## Software Requirements
 

--- a/influxdata/mad_check/README.md
+++ b/influxdata/mad_check/README.md
@@ -51,18 +51,6 @@ Multiple thresholds are separated by `@`: `temp:2.5:20:5@load:3:10:2m`
 - Count: `"MAD count alert: Field $field in $table outlier for $threshold_count consecutive points. Tags: $tags"`
 - Time: `"MAD duration alert: Field $field in $table outlier for $threshold_time. Tags: $tags"`
 
-### TOML configuration
-
-| Parameter          | Type   | Default | Description                                                                      |
-|--------------------|--------|---------|----------------------------------------------------------------------------------|
-| `config_file_path` | string | none    | TOML config file path relative to `PLUGIN_DIR` (required for TOML configuration) |
-
-*To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
-
-Example TOML configuration file provided: [mad_anomaly_config_data_writes.toml](mad_anomaly_config_data_writes.toml)
-
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
-
 ### Notification channel parameters
 
 #### Slack
@@ -95,6 +83,21 @@ For more information on using TOML configuration files, see the Using TOML Confi
 | `twilio_from_number` | string | Yes      | Sender phone number                             |
 | `twilio_to_number`   | string | Yes      | Recipient phone number                          |
 
+### TOML configuration
+
+| Parameter          | Type   | Default | Description                                                                      |
+|--------------------|--------|---------|----------------------------------------------------------------------------------|
+| `config_file_path` | string | none    | TOML config file path relative to `PLUGIN_DIR` (required for TOML configuration) |
+
+*To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
+
+#### Example TOML configuration
+
+[mad_anomaly_config_data_writes.toml](mad_anomaly_config_data_writes.toml)
+
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
+
 ## Software Requirements
 
 - **InfluxDB 3 Core/Enterprise**: with the Processing Engine enabled.
@@ -122,7 +125,7 @@ For more information on using TOML configuration files, see the Using TOML Confi
 
 3. *Optional*: For notifications, install and configure the [influxdata/notifier plugin](../notifier/README.md)
 
-## Data requirements
+## Schema requirement
 
 The plugin assumes that the table schema is already defined in the database, as it relies on this schema to retrieve field and tag names required for processing.
 

--- a/influxdata/prophet_forecasting/README.md
+++ b/influxdata/prophet_forecasting/README.md
@@ -87,8 +87,7 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 [prophet_forecasting_scheduler.toml](prophet_forecasting_scheduler.toml)
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ## Software Requirements
 

--- a/influxdata/prophet_forecasting/README.md
+++ b/influxdata/prophet_forecasting/README.md
@@ -83,9 +83,12 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 *To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
 
-Example TOML configuration file provided: [prophet_forecasting_scheduler.toml](prophet_forecasting_scheduler.toml)
+#### Example TOML configuration
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+[prophet_forecasting_scheduler.toml](prophet_forecasting_scheduler.toml)
+
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ## Software Requirements
 

--- a/influxdata/state_change/README.md
+++ b/influxdata/state_change/README.md
@@ -65,8 +65,7 @@ Example TOML configuration files provided:
 - [state_change_config_scheduler.toml](state_change_config_scheduler.toml) - for scheduled triggers
 - [state_change_config_data_writes.toml](state_change_config_data_writes.toml) - for data write triggers
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ### Channel-specific configuration
 

--- a/influxdata/state_change/README.md
+++ b/influxdata/state_change/README.md
@@ -65,13 +65,14 @@ Example TOML configuration files provided:
 - [state_change_config_scheduler.toml](state_change_config_scheduler.toml) - for scheduled triggers
 - [state_change_config_data_writes.toml](state_change_config_data_writes.toml) - for data write triggers
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ### Channel-specific configuration
 
 Notification channels require additional parameters based on the sender type (same as the [influxdata/notifier plugin](../notifier/README.md)).
 
-## Data requirements
+## Schema requirement
 
 The plugin assumes that the table schema is already defined in the database, as it relies on this schema to retrieve field and tag names required for processing.
 

--- a/influxdata/stateless_adtk_detector/README.md
+++ b/influxdata/stateless_adtk_detector/README.md
@@ -56,8 +56,7 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 [adtk_anomaly_config_scheduler.toml](adtk_anomaly_config_scheduler.toml)
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ### Supported ADTK detectors
 

--- a/influxdata/stateless_adtk_detector/README.md
+++ b/influxdata/stateless_adtk_detector/README.md
@@ -52,9 +52,12 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 *To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
 
-Example TOML configuration file provided: [adtk_anomaly_config_scheduler.toml](adtk_anomaly_config_scheduler.toml)
+#### Example TOML configuration
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+[adtk_anomaly_config_scheduler.toml](adtk_anomaly_config_scheduler.toml)
+
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ### Supported ADTK detectors
 

--- a/influxdata/system_metrics/README.md
+++ b/influxdata/system_metrics/README.md
@@ -39,8 +39,7 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 [system_metrics_config_scheduler.toml](system_metrics_config_scheduler.toml)
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ## Software Requirements
 

--- a/influxdata/system_metrics/README.md
+++ b/influxdata/system_metrics/README.md
@@ -35,9 +35,12 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 *To use a TOML configuration file, set the `PLUGIN_DIR` environment variable and specify the `config_file_path` in the trigger arguments.* This is in addition to the `--plugin-dir` flag when starting InfluxDB 3.
 
-Example TOML configuration file provided: [system_metrics_config_scheduler.toml](system_metrics_config_scheduler.toml)
+#### Example TOML configuration
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+[system_metrics_config_scheduler.toml](system_metrics_config_scheduler.toml)
+
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ## Software Requirements
 

--- a/influxdata/threshold_deadman_checks/README.md
+++ b/influxdata/threshold_deadman_checks/README.md
@@ -62,13 +62,14 @@ Example TOML configuration files provided:
 - [threshold_deadman_config_scheduler.toml](threshold_deadman_config_scheduler.toml) - for scheduled triggers
 - [threshold_deadman_config_data_writes.toml](threshold_deadman_config_data_writes.toml) - for data write triggers
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [project README](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
+/README.md](/README.md).
 
 ### Channel-specific configuration
 
 Notification channels require additional parameters based on the sender type (same as the [influxdata/notifier plugin](../notifier/README.md)).
 
-## Data requirements
+## Schema requirement
 
 The plugin assumes that the table schema is already defined in the database, as it relies on this schema to retrieve field and tag names required for processing.
 

--- a/influxdata/threshold_deadman_checks/README.md
+++ b/influxdata/threshold_deadman_checks/README.md
@@ -62,8 +62,7 @@ Example TOML configuration files provided:
 - [threshold_deadman_config_scheduler.toml](threshold_deadman_config_scheduler.toml) - for scheduled triggers
 - [threshold_deadman_config_data_writes.toml](threshold_deadman_config_data_writes.toml) - for data write triggers
 
-For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins
-/README.md](/README.md).
+For more information on using TOML configuration files, see the Using TOML Configuration Files section in the [influxdb3_plugins/README.md](/README.md).
 
 ### Channel-specific configuration
 


### PR DESCRIPTION
- Standardize TOML configuration section formatting with "#### Example TOML configuration" headers
- Fix broken project README link references (add influxdb3_plugins prefix)
- Standardize "Schema requirement" section naming across plugins
- Minor formatting improvements and consistency fixes