### PR TITLE
chore: bump black to >=24.0.0,<25.0.0

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -10,7 +10,7 @@ pytest-timeout>=2.1.0,<3.0.0
 pytest-cov>=4.1.0,<5.0.0
 
 # Code formatting and linting
-black>=23.0.0,<24.0.0
+black>=24.0.0,<25.0.0
 flake8>=6.0.0,<7.0.0
 mypy>=1.5.0,<2.0.0
 types-requests>=2.31.0,<3.0.0


### PR DESCRIPTION
Fyi, after setting up the venv, I did `black --check .` and it showed a lot of changes before and after this update.