### PR TITLE
fix: escape quote tag names in GROUP BY in downsampler

### DIFF
--- a/influxdata/downsampler/downsampler.py
+++ b/influxdata/downsampler/downsampler.py
@@ -827,9 +827,9 @@ def generate_group_by_string(tags_list: list):
     Returns:
         str: SQL GROUP BY clause string including '_time' and tags.
     """
-    group_by_clause: str = f"_time"
+    group_by_clause: str = "_time"
     for tag in tags_list:
-        group_by_clause += f", {tag}"
+        group_by_clause += f', "{tag}"'
     return group_by_clause
 
 


### PR DESCRIPTION
Addresses https://github.com/influxdata/influxdb3_plugins/issues/28

> [!IMPORTANT]
> I still need to test this out to make sure it fixes the related issue, which is why it is still in draft. 