### PR TITLE
refactor(import): credential handling only via headers

### DIFF
--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -419,10 +419,10 @@ curl -X POST "http://localhost:8181/api/v3/engine/import?action=resume&import_id
 
 ```bash
 curl -X POST http://localhost:8181/api/v3/engine/import?action=start \
+  -H "Source-Token: my-token" \
   -H "Content-Type: application/json" \
   -d '{
     "source_url": "http://localhost:8086",
-    "source_token": "my-token",
     "influxdb_version": 1,
     "source_database": "telegraf",
     "dry_run": true

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -275,12 +275,15 @@ Get list of databases from source InfluxDB instance.
 
 **Request**: `POST /api/v3/engine/import?action=databases`
 
+**Headers**:
+- `Source-Token: my-token` (or `Source-Username` + `Source-Password`)
+- `Content-Type: application/json`
+
 **Request body** (JSON):
 ```json
 {
   "source_url": "http://localhost:8086",
-  "influxdb_version": 1,
-  "source_token": "my-token"
+  "influxdb_version": 1
 }
 ```
 

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -671,9 +671,13 @@ influxdb3 query --database mydb "SELECT * FROM import_pause_state WHERE import_i
 
 #### `process_request(influxdb3_local, query_parameters, request_headers, request_body, args)`
 
-HTTP request handler that routes to appropriate import actions based on the `action` query parameter.
+HTTP request handler that routes to appropriate import actions based on the `action` query parameter. Extracts credentials from `request_headers` using `extract_credentials()` and passes them to action handlers.
 
-#### `start_import(influxdb3_local, config, task_id)`
+#### `extract_credentials(request_headers)`
+
+Extracts authentication credentials from HTTP headers. Returns a dict with keys `source_token`, `source_username`, `source_password` (values are `None` if header not present).
+
+#### `start_import(influxdb3_local, config, credentials, task_id)`
 
 Starts a new import process:
 1. Performs pre-flight checks (connectivity, measurements discovery)
@@ -681,7 +685,7 @@ Starts a new import process:
 3. Creates import configuration and state records
 4. Initiates table-by-table import
 
-#### `import_table(influxdb3_local, config, import_id, measurement, start_time, end_time, task_id, ...)`
+#### `import_table(influxdb3_local, config, credentials, import_id, measurement, start_time, end_time, task_id, ...)`
 
 Imports a single table:
 1. Finds actual data boundaries within specified range
@@ -691,7 +695,7 @@ Imports a single table:
 5. Writes to destination database
 6. Tracks progress and checks for pause/cancel signals
 
-#### `resume_import(influxdb3_local, import_id, task_id, ...)`
+#### `resume_import(influxdb3_local, import_id, credentials, task_id)`
 
 Resumes an interrupted import:
 1. Loads saved import configuration
@@ -713,7 +717,7 @@ Tests connectivity to a URL and identifies if it's an InfluxDB instance (5-secon
 5. Falls back to `cluster-uuid` header detection for v3 (returns `version: "3.x.x"`)
 6. Returns failure with message if not InfluxDB or unreachable
 
-#### `get_source_databases_list(body_data, session)`
+#### `get_source_databases_list(body_data, credentials, session)`
 
 Lists databases from source InfluxDB instance:
 1. Validates required parameters
@@ -721,7 +725,7 @@ Lists databases from source InfluxDB instance:
 3. For v2: Queries `/api/v2/buckets` API, filters out system buckets (prefixed with `_`)
 4. Returns sorted list of database names
 
-#### `get_source_tables_list(body_data, session)`
+#### `get_source_tables_list(body_data, credentials, session)`
 
 Lists tables/measurements from a source database:
 1. Validates required parameters including `source_database`

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -326,10 +326,10 @@ influxdb3 enable trigger --database mydb import_trigger
 
 # Start import via HTTP
 curl -X POST http://localhost:8181/api/v3/engine/import?action=start \
+  -H "Source-Token: my-super-secret-token" \
   -H "Content-Type: application/json" \
   -d '{
     "source_url": "http://localhost:8086",
-    "source_token": "my-super-secret-token",
     "influxdb_version": 1,
     "source_database": "telegraf",
     "dest_database": "imported_data"

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -576,7 +576,7 @@ When a import starts, the plugin loads configuration in this order:
 
 ```python
 # 1. Start with environment variables (lowest priority)
-IMPORT_SOURCE_URL, IMPORT_SOURCE_TOKEN, etc.
+IMPORT_SOURCE_URL, IMPORT_SOURCE_DATABASE, etc.
 
 # 2. Override with trigger arguments (--trigger-arguments)
 config_file_path=import_config.toml, source_url=http://localhost:8086, etc.
@@ -589,6 +589,9 @@ config_file_path=import_config.toml, source_url=http://localhost:8086, etc.
   "source_url": "http://localhost:8086",
   ...
 }
+
+# IMPORTANT: Credentials are ALWAYS extracted from HTTP headers (not from above sources)
+# Headers: Source-Token, Source-Username, Source-Password
 ```
 
 ### Environment Variables Supported

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -589,9 +589,6 @@ config_file_path=import_config.toml, source_url=http://localhost:8086, etc.
   "source_url": "http://localhost:8086",
   ...
 }
-
-# IMPORTANT: Credentials are ALWAYS extracted from HTTP headers (not from above sources)
-# Headers: Source-Token, Source-Username, Source-Password
 ```
 
 ### Environment Variables Supported
@@ -599,9 +596,6 @@ config_file_path=import_config.toml, source_url=http://localhost:8086, etc.
 The following environment variables can be used:
 
 - `IMPORT_SOURCE_URL` → `source_url`
-- `IMPORT_SOURCE_TOKEN` → `source_token`
-- `IMPORT_SOURCE_USERNAME` → `source_username`
-- `IMPORT_SOURCE_PASSWORD` → `source_password`
 - `IMPORT_SOURCE_DATABASE` → `source_database`
 - `IMPORT_DEST_DATABASE` → `dest_database`
 - `IMPORT_START_TIMESTAMP` → `start_timestamp`

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -784,12 +784,13 @@ During import, the plugin saves checkpoints:
 3. Verify credentials are correct
 4. For InfluxDB v2/v3, ensure you're using token authentication
 
-#### Issue: "Authentication error: Must provide either..." error
+#### Issue: Authentication errors from source InfluxDB
 
-**Solution**: Choose one authentication method:
-- For token: Provide only `source_token`
-- For username/password: Provide both `source_username` AND `source_password` together
-- Do not mix authentication methods
+**Solution**: Pass credentials via HTTP headers:
+1. For token auth: Add header `-H "Source-Token: your-token"`
+2. For username/password: Add headers `-H "Source-Username: user" -H "Source-Password: pass"`
+3. Verify credentials work directly against source InfluxDB
+4. Check that headers are not being stripped by proxies
 
 #### Issue: "Import already completed" when trying to resume
 

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -293,13 +293,16 @@ Get list of tables/measurements from a source database.
 
 **Request**: `POST /api/v3/engine/import?action=tables`
 
+**Headers**:
+- `Source-Token: my-token` (or `Source-Username` + `Source-Password`)
+- `Content-Type: application/json`
+
 **Request body** (JSON):
 ```json
 {
   "source_url": "http://localhost:8086",
   "influxdb_version": 1,
-  "source_database": "telegraf",
-  "source_token": "my-token"
+  "source_database": "telegraf"
 }
 ```
 

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -535,15 +535,14 @@ This plugin supports using TOML configuration files to specify all plugin argume
    influxdb_version = 1
    source_database = "telegraf"
 
-   # Authentication (choose one method)
-   source_token = "my-token"
-
    # Optional parameters
    dest_database = "imported_data"
    start_timestamp = "2024-01-01T00:00:00Z"
    end_timestamp = "2024-12-31T23:59:59Z"
    table_filter = "cpu.mem.disk"
    ```
+
+> **Note**: Credentials are NOT stored in TOML files. Provide them via HTTP headers on each request.
 
 4. **Create a trigger using the `config_file_path` argument**:
 

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -381,10 +381,10 @@ Monitor and control a long-running import:
 ```bash
 # Start import (logs import_id, does not return it immediately)
 curl -X POST http://localhost:8181/api/v3/engine/import?action=start \
+  -H "Source-Token: my-token" \
   -H "Content-Type: application/json" \
   -d '{
     "source_url": "http://localhost:8086",
-    "source_token": "my-token",
     "influxdb_version": 2,
     "source_database": "large_database",
     "dest_database": "imported"
@@ -404,10 +404,7 @@ curl "http://localhost:8181/api/v3/engine/import?action=status&import_id=$IMPORT
 
 # Resume later
 curl -X POST "http://localhost:8181/api/v3/engine/import?action=resume&import_id=$IMPORT_ID" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "source_token": "my-token"
-  }'
+  -H "Source-Token: my-token"
 ```
 
 ### Expected results

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -351,11 +351,11 @@ Import specific tables within a date range:
 ```bash
 # Start import with time range and table filter
 curl -X POST http://localhost:8181/api/v3/engine/import?action=start \
+  -H "Source-Username: admin" \
+  -H "Source-Password: my-password" \
   -H "Content-Type: application/json" \
   -d '{
     "source_url": "http://influxdb-source.example.com:8086",
-    "source_username": "admin",
-    "source_password": "my-password",
     "influxdb_version": 1,
     "source_database": "telegraf",
     "dest_database": "production_metrics",

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -36,22 +36,48 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 | `influxdb_version`  | integer | required | Source InfluxDB version: 1, 2, or 3                                |
 | `source_database`   | string  | required | Source database name to import from                               |
 
-### Authentication parameters (required - choose one method)
+### Authentication
 
-**Method 1: Token-based authentication** (InfluxDB v2 or v1 with token support)
+Credentials are passed via HTTP headers on each request.
 
-| Parameter      | Type   | Required | Description                                      |
-|----------------|--------|----------|--------------------------------------------------|
-| `source_token` | string | Yes      | Authentication token for the source InfluxDB     |
+| Header | Purpose |
+|--------|---------|
+| `Source-Token` | Bearer/API token authentication (InfluxDB v1/v2/v3) |
+| `Source-Username` | Basic auth username (InfluxDB v1) |
+| `Source-Password` | Basic auth password (InfluxDB v1) |
 
-**Method 2: Username/Password authentication** (InfluxDB v1)
+**Method 1: Token-based authentication**
 
-| Parameter         | Type   | Required | Description                                                |
-|-------------------|--------|----------|------------------------------------------------------------|
-| `source_username` | string | Yes      | Username for basic authentication (must use with password) |
-| `source_password` | string | Yes      | Password for basic authentication (must use with username) |
+Use the `Source-Token` header for token-based authentication:
 
-> **Note**: You must provide EITHER `source_token` OR (`source_username` AND `source_password` together). Using both methods simultaneously will result in an error.
+```bash
+curl -X POST http://localhost:8181/api/v3/engine/import?action=start \
+  -H "Content-Type: application/json" \
+  -H "Source-Token: my-secret-token" \
+  -d '{
+    "source_url": "http://localhost:8086",
+    "influxdb_version": 2,
+    "source_database": "telegraf"
+  }'
+```
+
+**Method 2: Username/Password authentication**
+
+Use the `Source-Username` and `Source-Password` headers for basic authentication:
+
+```bash
+curl -X POST http://localhost:8181/api/v3/engine/import?action=start \
+  -H "Content-Type: application/json" \
+  -H "Source-Username: admin" \
+  -H "Source-Password: my-password" \
+  -d '{
+    "source_url": "http://localhost:8086",
+    "influxdb_version": 1,
+    "source_database": "telegraf"
+  }'
+```
+
+> **Note**: Authentication errors from the source InfluxDB are returned directly. The plugin does not validate credentials upfront.
 
 ### Optional parameters
 

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -163,11 +163,14 @@ Start a new import from source InfluxDB to InfluxDB 3.
 
 **Request**: `POST /api/v3/engine/import?action=start`
 
+**Headers**:
+- `Source-Token: my-token` (or `Source-Username` + `Source-Password`)
+- `Content-Type: application/json`
+
 **Request body** (JSON):
 ```json
 {
   "source_url": "http://localhost:8086",
-  "source_token": "my-token",
   "influxdb_version": 1,
   "source_database": "telegraf",
   "dest_database": "imported_data",

--- a/influxdata/import/README.md
+++ b/influxdata/import/README.md
@@ -201,25 +201,12 @@ Resume a paused or interrupted import.
 
 **Request**: `POST /api/v3/engine/import?action=resume&import_id=<import_id>`
 
-**Request body** (JSON):
-```json
-{
-  "source_token": "my-token"
-}
-```
-*or*
-```json
-{
-  "source_username": "admin",
-  "source_password": "my-password"
-}
-```
-*or*
-```
-`POST /api/v3/engine/import?action=resume&import_id=<import_id>&source_token=your_token`
-```
+**Headers**:
+- `Source-Token: my-token` (or `Source-Username` + `Source-Password`)
 
-> **Note**: Authentication credentials are not stored for security reasons and must be provided when resuming. Returns error if import is not found, already cancelled, or already running.
+> **Note**: Credentials must be provided via headers when resuming.
+
+> **Note**: Returns error if import is not found, already cancelled, or already running.
 
 ### Cancel Import
 

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -203,9 +203,6 @@ def load_config(
     # 1. Start with environment variables (lowest priority)
     env_mappings = {
         "IMPORT_SOURCE_URL": "source_url",
-        "IMPORT_SOURCE_TOKEN": "source_token",
-        "IMPORT_SOURCE_USERNAME": "source_username",
-        "IMPORT_SOURCE_PASSWORD": "source_password",
         "IMPORT_SOURCE_DATABASE": "source_database",
         "IMPORT_DEST_DATABASE": "dest_database",
         "IMPORT_START_TIMESTAMP": "start_timestamp",
@@ -262,30 +259,6 @@ def load_config(
         config_data["table_filter"] = [
             t.strip() for t in config_data["table_filter"].split(".")
         ]
-
-    # Validate authentication parameters
-    has_username = config_data.get("source_username")
-    has_password = config_data.get("source_password")
-    has_token = config_data.get("source_token")
-
-    # Check that either (username AND password together) OR (only token) is provided
-    if has_username or has_password:
-        # If username or password is provided, both must be provided
-        if not (has_username and has_password):
-            raise ValueError(
-                "Authentication error: source_username and source_password must be provided together"
-            )
-        # If both username and password are provided, token should NOT be provided
-        if has_token:
-            raise ValueError(
-                "Authentication error: Cannot use both (source_username/source_password) and source_token. "
-                "Please provide either (source_username and source_password) OR (source_token only)"
-            )
-    elif not has_token:
-        # Neither username/password nor token is provided
-        raise ValueError(
-            "Authentication error: Must provide either (source_username and source_password) OR (source_token)"
-        )
 
     return ImportConfig(**config_data)
 

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -2408,11 +2408,6 @@ def resume_import(
         )
 
         # 4. Resume the import using resume_incomplete_import
-        credentials = {
-            "source_token": source_token,
-            "source_username": source_username,
-            "source_password": source_password,
-        }
         return resume_incomplete_import(
             influxdb3_local,
             config,

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -112,6 +112,9 @@ def extract_credentials(request_headers: Dict[str, str]) -> Dict[str, Optional[s
     """
     Extract credentials from HTTP headers.
 
+    Note: InfluxDB3 normalizes header keys to lowercase, so we look up
+    lowercase keys directly.
+
     Args:
         request_headers: HTTP request headers dict
 
@@ -120,9 +123,9 @@ def extract_credentials(request_headers: Dict[str, str]) -> Dict[str, Optional[s
         Values are None if header not present
     """
     return {
-        "source_token": request_headers.get("Source-Token"),
-        "source_username": request_headers.get("Source-Username"),
-        "source_password": request_headers.get("Source-Password"),
+        "source_token": request_headers.get("source-token"),
+        "source_username": request_headers.get("source-username"),
+        "source_password": request_headers.get("source-password"),
     }
 
 

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -9,24 +9,6 @@
             "required": true
         },
         {
-            "name": "source_token",
-            "example": "my-token",
-            "description": "Source InfluxDB authentication token.",
-            "required": false
-        },
-        {
-            "name": "source_username",
-            "example": "admin",
-            "description": "Source InfluxDB authentication username.",
-            "required": false
-        },
-        {
-            "name": "source_password",
-            "example": "my-password",
-            "description": "Source InfluxDB authentication password.",
-            "required": false
-        },
-        {
             "name": "influxdb_version",
             "example": 1,
             "description": "Source InfluxDB version: 1, 2, or 3.",

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -126,6 +126,24 @@ REQUEST_TIMEOUT_SECONDS = 30
 MICROSECOND_OFFSET = 1
 
 
+def extract_credentials(request_headers: Dict[str, str]) -> Dict[str, Optional[str]]:
+    """
+    Extract credentials from HTTP headers.
+
+    Args:
+        request_headers: HTTP request headers dict
+
+    Returns:
+        Dict with keys: source_token, source_username, source_password
+        Values are None if header not present
+    """
+    return {
+        "source_token": request_headers.get("Source-Token"),
+        "source_username": request_headers.get("Source-Username"),
+        "source_password": request_headers.get("Source-Password"),
+    }
+
+
 class ImportPauseState(Enum):
     """Possible states returned from querying the import_pause_state table."""
 

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -1247,15 +1247,13 @@ def save_import_config(
 def load_import_config(
     influxdb3_local,
     import_id: str,
+    credentials: Dict[str, Optional[str]],
     task_id: str,
-    source_token: str = None,
-    source_username: str = None,
-    source_password: str = None,
 ) -> Optional[ImportConfig]:
     """
     Load import configuration from database
     Returns ImportConfig or None if not found
-    Authentication credentials must be provided as parameters since they're not stored in DB for security
+    Authentication credentials must be provided in credentials dict since they're not stored in DB for security
     """
     try:
         query = f"""
@@ -1286,9 +1284,9 @@ def load_import_config(
         # Reconstruct ImportConfig from saved data
         config = ImportConfig(
             source_url=row.get("source_url"),
-            source_token=source_token,
-            source_username=source_username,
-            source_password=source_password,
+            source_token=credentials.get("source_token"),
+            source_username=credentials.get("source_username"),
+            source_password=credentials.get("source_password"),
             source_database=row.get("source_database"),
             dest_database=row.get("dest_database"),
             influxdb_version=int(row.get("influxdb_version", 1)),
@@ -2282,15 +2280,13 @@ def pause_import(influxdb3_local, import_id: str, task_id: str) -> Dict[str, Any
 def resume_import(
     influxdb3_local,
     import_id: str,
+    credentials: Dict[str, Optional[str]],
     task_id: str,
-    source_token: str = None,
-    source_username: str = None,
-    source_password: str = None,
 ) -> Dict[str, Any]:
     """
     Resume a paused or incomplete import
     Checks import status and continues from where it stopped
-    Requires either source_token OR (source_username AND source_password)
+    Requires either source_token OR (source_username AND source_password) in credentials dict
     """
     try:
         influxdb3_local.info(
@@ -2354,10 +2350,8 @@ def resume_import(
         config = load_import_config(
             influxdb3_local,
             import_id,
+            credentials,
             task_id,
-            source_token,
-            source_username,
-            source_password,
         )
         if not config:
             return {
@@ -2914,12 +2908,14 @@ def check_source_connection(
 
 def get_source_databases_list(
     body_data: Dict[str, Any],
+    credentials: Dict[str, Optional[str]],
     session: requests.Session = None,
 ) -> Dict[str, Any]:
     """Get list of databases from source InfluxDB instance.
 
     Args:
-        body_data: Dict containing source_url, influxdb_version, and auth credentials
+        body_data: Dict containing source_url and influxdb_version
+        credentials: Dict containing auth credentials (source_token, source_username, source_password)
         session: Optional requests.Session for dependency injection (testing)
 
     Returns:
@@ -2934,18 +2930,10 @@ def get_source_databases_list(
 
     source_url = body_data.get("source_url")
     influxdb_version = body_data.get("influxdb_version")
-    source_token = body_data.get("source_token")
-    source_username = body_data.get("source_username")
-    source_password = body_data.get("source_password")
 
     base_url = _parse_url_with_port_inference(source_url)
 
     try:
-        credentials = {
-            "source_token": source_token,
-            "source_username": source_username,
-            "source_password": source_password,
-        }
 
         if influxdb_version == 1:
             headers = _build_v1_headers(credentials)
@@ -3002,12 +2990,14 @@ def get_source_databases_list(
 
 def get_source_tables_list(
     body_data: Dict[str, Any],
+    credentials: Dict[str, Optional[str]],
     session: requests.Session = None,
 ) -> Dict[str, Any]:
     """Get list of tables/measurements from source database.
 
     Args:
-        body_data: Dict containing source_url, influxdb_version, source_database, and auth credentials
+        body_data: Dict containing source_url, influxdb_version, and source_database
+        credentials: Dict containing auth credentials (source_token, source_username, source_password)
         session: Optional requests.Session for dependency injection (testing)
 
     Returns:
@@ -3023,21 +3013,12 @@ def get_source_tables_list(
     source_url = body_data.get("source_url")
     influxdb_version = body_data.get("influxdb_version")
     source_database = body_data.get("source_database")
-    source_token = body_data.get("source_token")
-    source_username = body_data.get("source_username")
-    source_password = body_data.get("source_password")
     source_org = body_data.get("source_org")
 
     if not source_database:
         return {"error": "source_database is required"}
 
     base_url = _parse_url_with_port_inference(source_url)
-
-    credentials = {
-        "source_token": source_token,
-        "source_username": source_username,
-        "source_password": source_password,
-    }
 
     try:
         if influxdb_version == 1:
@@ -3159,47 +3140,11 @@ def process_request(
             if not import_id:
                 return {"status": "error", "error": "import_id required"}
 
-            # Get authentication credentials from query parameters or request body for resume
-            # Parse request body if JSON
-            body_data: dict = json.loads(request_body) if request_body else {}
-
-            # Try to get credentials from body first, then from query parameters
-            source_token = body_data.get("source_token") or query_parameters.get(
-                "source_token"
-            )
-            source_username = body_data.get("source_username") or query_parameters.get(
-                "source_username"
-            )
-            source_password = body_data.get("source_password") or query_parameters.get(
-                "source_password"
-            )
-
-            # Validate that either (username AND password) OR (token) is provided
-            if source_username or source_password:
-                if not (source_username and source_password):
-                    return {
-                        "status": "error",
-                        "error": "source_username and source_password must be provided together",
-                    }
-                if source_token:
-                    return {
-                        "status": "error",
-                        "error": "Cannot use both (source_username/source_password) and source_token. "
-                        "Please provide either (source_username and source_password) OR (source_token only)",
-                    }
-            elif not source_token:
-                return {
-                    "status": "error",
-                    "error": "Must provide either (source_username and source_password) OR (source_token) for resume action",
-                }
-
             return resume_import(
                 influxdb3_local,
                 import_id,
+                credentials,
                 task_id,
-                source_token,
-                source_username,
-                source_password,
             )
 
         elif action == "cancel":
@@ -3216,14 +3161,14 @@ def process_request(
 
         elif action == "databases":
             body_data = json.loads(request_body) if request_body else {}
-            result = get_source_databases_list(body_data)
+            result = get_source_databases_list(body_data, credentials)
             if result.get("error"):
                 influxdb3_local.error(f"[{task_id}] databases failed: {result.get('error')}")
             return result
 
         elif action == "tables":
             body_data = json.loads(request_body) if request_body else {}
-            result = get_source_tables_list(body_data)
+            result = get_source_tables_list(body_data, credentials)
             if result.get("error"):
                 influxdb3_local.error(f"[{task_id}] tables failed: {result.get('error')}")
             return result

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -168,9 +168,6 @@ class ImportConfig:
     target_batch_size: int = 2000
     table_filter: Optional[List[str]] = None
     config_file_path: Optional[str] = None
-    source_token: Optional[str] = None
-    source_username: Optional[str] = None
-    source_password: Optional[str] = None
     dry_run: bool = False
 
 

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -274,6 +274,7 @@ def get_http_session() -> requests.Session:
 def query_source_influxdb(
     influxdb3_local,
     config: ImportConfig,
+    credentials: Dict[str, Optional[str]],
     query: str,
     task_id: str,
 ) -> Dict[str, Any]:
@@ -291,29 +292,16 @@ def query_source_influxdb(
 
     headers = {"Content-Type": "application/vnd.influxql"}
 
-    # Determine authentication method based on InfluxDB version
+    # Build auth headers based on version
     if config.influxdb_version == 1:
-        # InfluxDB v1 authentication
-        if config.source_username and config.source_password:
-            # Basic Authentication with username:password
-            credentials = f"{config.source_username}:{config.source_password}"
-            encoded_credentials = base64.b64encode(credentials.encode()).decode()
-            headers["Authorization"] = f"Basic {encoded_credentials}"
-        elif config.source_token:
-            # Bearer token authentication for v1
-            headers["Authorization"] = f"Bearer {config.source_token}"
+        auth_headers = _build_v1_headers(credentials)
+        headers.update(auth_headers)
     elif config.influxdb_version == 2:
-        # InfluxDB v2 authentication (requires token)
-        if config.source_token:
-            headers["Authorization"] = f"Token {config.source_token}"
-        else:
-            raise ValueError("InfluxDB v2 requires source_token for authentication")
+        auth_headers = _build_v2_headers(credentials)
+        headers.update(auth_headers)
     elif config.influxdb_version == 3:
-        # InfluxDB v3 authentication (Bearer token)
-        if config.source_token:
-            headers["Authorization"] = f"Bearer {config.source_token}"
-        else:
-            raise ValueError("InfluxDB v3 requires source_token for authentication")
+        auth_headers = _build_v3_headers(credentials)
+        headers.update(auth_headers)
 
     retry_count = 0
     backoff = INITIAL_BACKOFF_SECONDS
@@ -348,11 +336,11 @@ def query_source_influxdb(
 
 
 def get_source_measurements(
-    influxdb3_local, config: ImportConfig, task_id: str
+    influxdb3_local, config: ImportConfig, credentials: Dict[str, Optional[str]], task_id: str
 ) -> List[str]:
     """Get list of measurements (tables) from source database"""
     result = query_source_influxdb(
-        influxdb3_local, config, "SHOW MEASUREMENTS", task_id
+        influxdb3_local, config, credentials, "SHOW MEASUREMENTS", task_id
     )
 
     measurements = []
@@ -369,11 +357,11 @@ def get_source_measurements(
 
 
 def get_field_keys(
-    influxdb3_local, config: ImportConfig, measurement: str, task_id: str
+    influxdb3_local, config: ImportConfig, credentials: Dict[str, Optional[str]], measurement: str, task_id: str
 ) -> Dict[str, str]:
     """Get field keys and their types for a measurement"""
     query = f'SHOW FIELD KEYS FROM "{measurement}"'
-    result = query_source_influxdb(influxdb3_local, config, query, task_id)
+    result = query_source_influxdb(influxdb3_local, config, credentials, query, task_id)
 
     fields = {}
     if "results" in result and len(result["results"]) > 0:
@@ -387,11 +375,11 @@ def get_field_keys(
 
 
 def get_tag_keys(
-    influxdb3_local, config: ImportConfig, measurement: str, task_id: str
+    influxdb3_local, config: ImportConfig, credentials: Dict[str, Optional[str]], measurement: str, task_id: str
 ) -> List[str]:
     """Get tag keys for a measurement"""
     query = f'SHOW TAG KEYS FROM "{measurement}"'
-    result = query_source_influxdb(influxdb3_local, config, query, task_id)
+    result = query_source_influxdb(influxdb3_local, config, credentials, query, task_id)
 
     tags = []
     if "results" in result and len(result["results"]) > 0:
@@ -414,6 +402,7 @@ def check_tag_field_conflicts(tags: List[str], fields: Dict[str, str]) -> List[s
 def estimate_import_time(
     influxdb3_local,
     config: ImportConfig,
+    credentials: Dict[str, Optional[str]],
     measurements: List[str],
     start_dt: datetime,
     end_dt: datetime,
@@ -442,7 +431,7 @@ def estimate_import_time(
         try:
             # Get actual data boundaries
             actual_start, actual_end = find_actual_data_boundaries(
-                influxdb3_local, config, measurement, start_dt, end_dt, task_id
+                influxdb3_local, config, credentials, measurement, start_dt, end_dt, task_id
             )
 
             if not actual_start or not actual_end:
@@ -469,7 +458,7 @@ def estimate_import_time(
             """
 
             result = query_source_influxdb(
-                influxdb3_local, config, count_query, task_id
+                influxdb3_local, config, credentials, count_query, task_id
             )
 
             row_count = 0
@@ -536,7 +525,7 @@ def estimate_import_time(
 
 
 def perform_preflight_checks(
-    influxdb3_local, config: ImportConfig, task_id: str
+    influxdb3_local, config: ImportConfig, credentials: Dict[str, Optional[str]], task_id: str
 ) -> Tuple[bool, List[str], Dict[str, Any]]:
     """
     Perform pre-flight validation checks
@@ -554,7 +543,7 @@ def perform_preflight_checks(
 
     # Check source connectivity
     try:
-        measurements = get_source_measurements(influxdb3_local, config, task_id)
+        measurements = get_source_measurements(influxdb3_local, config, credentials, task_id)
         metadata["measurements"] = measurements
         metadata["total_tables"] = len(measurements)
         influxdb3_local.info(
@@ -612,6 +601,7 @@ def parse_timestamp(ts_str: str) -> datetime:
 def find_actual_data_boundaries(
     influxdb3_local,
     config: ImportConfig,
+    credentials: Dict[str, Optional[str]],
     measurement: str,
     user_start: Optional[datetime],
     user_end: Optional[datetime],
@@ -676,7 +666,7 @@ def find_actual_data_boundaries(
 
     try:
         # --- Query for actual_start ---
-        result = query_source_influxdb(influxdb3_local, config, start_query, task_id)
+        result = query_source_influxdb(influxdb3_local, config, credentials, start_query, task_id)
         if "results" in result and result["results"][0].get("series"):
             series = result["results"][0]["series"][0]
             if "values" in series and series["values"]:
@@ -686,7 +676,7 @@ def find_actual_data_boundaries(
                 )
 
         # --- Query for actual_end ---
-        result = query_source_influxdb(influxdb3_local, config, end_query, task_id)
+        result = query_source_influxdb(influxdb3_local, config, credentials, end_query, task_id)
         if "results" in result and result["results"][0].get("series"):
             series = result["results"][0]["series"][0]
             if "values" in series and series["values"]:
@@ -708,6 +698,7 @@ def find_actual_data_boundaries(
 def sample_data_density(
     influxdb3_local,
     config: ImportConfig,
+    credentials: Dict[str, Optional[str]],
     measurement: str,
     start: datetime,
     end: datetime,
@@ -764,7 +755,7 @@ def sample_data_density(
             """
 
             try:
-                result = query_source_influxdb(influxdb3_local, config, query, task_id)
+                result = query_source_influxdb(influxdb3_local, config, credentials, query, task_id)
                 if "results" in result and result["results"][0].get("series"):
                     series = result["results"][0]["series"][0]
                     if "values" in series and series["values"]:
@@ -1413,6 +1404,7 @@ def check_pause_state(
 def import_table(
     influxdb3_local,
     config: ImportConfig,
+    credentials: Dict[str, Optional[str]],
     import_id: str,
     measurement: str,
     start_time: datetime,
@@ -1431,7 +1423,7 @@ def import_table(
 
     # Find actual data boundaries
     actual_start, actual_end = find_actual_data_boundaries(
-        influxdb3_local, config, measurement, start_time, end_time, task_id
+        influxdb3_local, config, credentials, measurement, start_time, end_time, task_id
     )
 
     if not actual_start or not actual_end:
@@ -1458,12 +1450,12 @@ def import_table(
 
     # Calculate optimal batch window
     optimal_window_seconds = sample_data_density(
-        influxdb3_local, config, measurement, actual_start, actual_end, task_id
+        influxdb3_local, config, credentials, measurement, actual_start, actual_end, task_id
     )
 
     # Get schema info for conflict detection
-    fields = get_field_keys(influxdb3_local, config, measurement, task_id)
-    tags = get_tag_keys(influxdb3_local, config, measurement, task_id)
+    fields = get_field_keys(influxdb3_local, config, credentials, measurement, task_id)
+    tags = get_tag_keys(influxdb3_local, config, credentials, measurement, task_id)
     conflicts = check_tag_field_conflicts(tags, fields)
 
     # Add schema issues to metadata if conflicts found
@@ -1601,7 +1593,7 @@ def import_table(
             influxdb3_local.info(
                 f"[{task_id}] Querying data for '{measurement}' from {window_start} to {window_end}"
             )
-            result = query_source_influxdb(influxdb3_local, config, query, task_id)
+            result = query_source_influxdb(influxdb3_local, config, credentials, query, task_id)
 
             if "results" in result and result["results"][0].get("series"):
                 series = result["results"][0]["series"][0]
@@ -1697,6 +1689,7 @@ def import_table(
 def resume_incomplete_import(
     influxdb3_local,
     config: ImportConfig,
+    credentials: Dict[str, Optional[str]],
     import_id: str,
     incomplete_tables: List[Dict[str, Any]],
     task_id: str,
@@ -1754,6 +1747,7 @@ def resume_incomplete_import(
             table_result = import_table(
                 influxdb3_local,
                 config,
+                credentials,
                 import_id,
                 measurement,
                 start_dt,
@@ -1777,6 +1771,7 @@ def resume_incomplete_import(
             table_result = import_table(
                 influxdb3_local,
                 config,
+                credentials,
                 import_id,
                 measurement,
                 resume_start,
@@ -1810,6 +1805,7 @@ def resume_incomplete_import(
             table_result = import_table(
                 influxdb3_local,
                 config,
+                credentials,
                 import_id,
                 measurement,
                 start_dt,
@@ -1967,7 +1963,7 @@ def generate_import_plan(
     return import_plan
 
 
-def start_import(influxdb3_local, config: ImportConfig, task_id: str) -> Dict[str, Any]:
+def start_import(influxdb3_local, config: ImportConfig, credentials: Dict[str, Optional[str]], task_id: str) -> Dict[str, Any]:
     """
     Start a new import process
     Returns import_id and initial status
@@ -2023,7 +2019,7 @@ def start_import(influxdb3_local, config: ImportConfig, task_id: str) -> Dict[st
 
     # Perform pre-flight checks
     success, errors, metadata = perform_preflight_checks(
-        influxdb3_local, config, task_id
+        influxdb3_local, config, credentials, task_id
     )
 
     if not success:
@@ -2055,7 +2051,7 @@ def start_import(influxdb3_local, config: ImportConfig, task_id: str) -> Dict[st
         f"[{task_id}] Estimating import time based on data sampling..."
     )
     time_estimate = estimate_import_time(
-        influxdb3_local, config, measurements, start_dt, end_dt, task_id
+        influxdb3_local, config, credentials, measurements, start_dt, end_dt, task_id
     )
     metadata["time_estimate"] = time_estimate
 
@@ -2110,6 +2106,7 @@ def start_import(influxdb3_local, config: ImportConfig, task_id: str) -> Dict[st
         table_result = import_table(
             influxdb3_local,
             config,
+            credentials,
             import_id,
             measurement,
             start_dt,
@@ -2420,9 +2417,15 @@ def resume_import(
         )
 
         # 4. Resume the import using resume_incomplete_import
+        credentials = {
+            "source_token": source_token,
+            "source_username": source_username,
+            "source_password": source_password,
+        }
         return resume_incomplete_import(
             influxdb3_local,
             config,
+            credentials,
             import_id,
             incomplete_tables,
             task_id,
@@ -3125,6 +3128,9 @@ def process_request(
     action = query_parameters.get("action", "start")
     import_id = query_parameters.get("import_id")
 
+    # Extract credentials from request headers (available for all actions)
+    credentials = extract_credentials(request_headers)
+
     try:
         # Handle different actions
         if action == "start":
@@ -3137,7 +3143,7 @@ def process_request(
                 return {"status": "error", "error": f"Configuration error: {e}"}
 
             # Start import
-            return start_import(influxdb3_local, config, task_id)
+            return start_import(influxdb3_local, config, credentials, task_id)
 
         elif action == "status":
             if not import_id:

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -2771,25 +2771,16 @@ def _parse_url_with_port_inference(source_url: str) -> str:
         return source_url
 
 
-def _build_v1_headers(
-    username: str = None,
-    password: str = None,
-    token: str = None,
-) -> Dict[str, str]:
-    """Build headers for InfluxDB v1 API requests.
-
-    Args:
-        username: Optional username for Basic auth
-        password: Optional password for Basic auth
-        token: Optional token for Bearer auth
-
-    Returns:
-        Headers dict with Content-Type and optional Authorization
-    """
+def _build_v1_headers(credentials: Dict[str, Optional[str]]) -> Dict[str, str]:
+    """Build headers for InfluxDB v1 API requests."""
     headers = {"Content-Type": "application/json"}
+    username = credentials.get("source_username")
+    password = credentials.get("source_password")
+    token = credentials.get("source_token")
+
     if username and password:
-        credentials = f"{username}:{password}"
-        encoded = base64.b64encode(credentials.encode()).decode()
+        creds = f"{username}:{password}"
+        encoded = base64.b64encode(creds.encode()).decode()
         headers["Authorization"] = f"Basic {encoded}"
     elif token:
         headers["Authorization"] = f"Bearer {token}"
@@ -2797,36 +2788,23 @@ def _build_v1_headers(
 
 
 def _build_v2_headers(
-    token: str = None,
+    credentials: Dict[str, Optional[str]],
     extra_headers: Dict[str, str] = None,
 ) -> Dict[str, str]:
-    """Build headers for InfluxDB v2 API requests.
-
-    Args:
-        token: Optional token for Token auth
-        extra_headers: Optional additional headers to include
-
-    Returns:
-        Headers dict with optional Authorization and extra headers
-    """
+    """Build headers for InfluxDB v2 API requests."""
     headers = {}
     if extra_headers:
         headers.update(extra_headers)
+    token = credentials.get("source_token")
     if token:
         headers["Authorization"] = f"Token {token}"
     return headers
 
 
-def _build_v3_headers(token: str = None) -> Dict[str, str]:
-    """Build headers for InfluxDB v3 API requests.
-
-    Args:
-        token: Optional token for Bearer auth
-
-    Returns:
-        Headers dict with Content-Type and optional Authorization
-    """
+def _build_v3_headers(credentials: Dict[str, Optional[str]]) -> Dict[str, str]:
+    """Build headers for InfluxDB v3 API requests."""
     headers = {"Content-Type": "application/json"}
+    token = credentials.get("source_token")
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
@@ -2960,8 +2938,14 @@ def get_source_databases_list(
     base_url = _parse_url_with_port_inference(source_url)
 
     try:
+        credentials = {
+            "source_token": source_token,
+            "source_username": source_username,
+            "source_password": source_password,
+        }
+
         if influxdb_version == 1:
-            headers = _build_v1_headers(source_username, source_password, source_token)
+            headers = _build_v1_headers(credentials)
 
             response = session.get(
                 f"{base_url}/query",
@@ -2976,7 +2960,7 @@ def get_source_databases_list(
             return {"databases": sorted(databases)}
 
         elif influxdb_version == 2:
-            headers = _build_v2_headers(source_token)
+            headers = _build_v2_headers(credentials)
 
             response = session.get(
                 f"{base_url}/api/v2/buckets",
@@ -2994,7 +2978,7 @@ def get_source_databases_list(
             return {"databases": sorted(databases)}
 
         elif influxdb_version == 3:
-            headers = _build_v3_headers(source_token)
+            headers = _build_v3_headers(credentials)
 
             response = session.get(
                 f"{base_url}/api/v3/configure/database",
@@ -3046,9 +3030,15 @@ def get_source_tables_list(
 
     base_url = _parse_url_with_port_inference(source_url)
 
+    credentials = {
+        "source_token": source_token,
+        "source_username": source_username,
+        "source_password": source_password,
+    }
+
     try:
         if influxdb_version == 1:
-            headers = _build_v1_headers(source_username, source_password, source_token)
+            headers = _build_v1_headers(credentials)
 
             response = session.get(
                 f"{base_url}/query",
@@ -3066,7 +3056,7 @@ def get_source_tables_list(
                 return {"error": "source_org is required for InfluxDB v2"}
 
             headers = _build_v2_headers(
-                source_token,
+                credentials,
                 extra_headers={
                     "Content-Type": "application/vnd.flux",
                     "Accept": "application/csv",
@@ -3096,7 +3086,7 @@ def get_source_tables_list(
             return {"tables": sorted(tables)}
 
         elif influxdb_version == 3:
-            headers = _build_v3_headers(source_token)
+            headers = _build_v3_headers(credentials)
 
             response = session.get(
                 f"{base_url}/api/v3/query_sql",

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -1284,9 +1284,6 @@ def load_import_config(
         # Reconstruct ImportConfig from saved data
         config = ImportConfig(
             source_url=row.get("source_url"),
-            source_token=credentials.get("source_token"),
-            source_username=credentials.get("source_username"),
-            source_password=credentials.get("source_password"),
             source_database=row.get("source_database"),
             dest_database=row.get("dest_database"),
             influxdb_version=int(row.get("influxdb_version", 1)),

--- a/influxdata/import/test_import.py
+++ b/influxdata/import/test_import.py
@@ -525,7 +525,8 @@ class TestExtractCredentials:
 
     def test_extracts_token_from_headers(self):
         extract_credentials = import_module.extract_credentials
-        headers = {"Source-Token": "my-secret-token"}
+        # InfluxDB3 normalizes headers to lowercase
+        headers = {"source-token": "my-secret-token"}
         result = extract_credentials(headers)
         assert result == {
             "source_token": "my-secret-token",
@@ -535,9 +536,10 @@ class TestExtractCredentials:
 
     def test_extracts_username_password_from_headers(self):
         extract_credentials = import_module.extract_credentials
+        # InfluxDB3 normalizes headers to lowercase
         headers = {
-            "Source-Username": "admin",
-            "Source-Password": "secret123",
+            "source-username": "admin",
+            "source-password": "secret123",
         }
         result = extract_credentials(headers)
         assert result == {
@@ -558,10 +560,11 @@ class TestExtractCredentials:
 
     def test_extracts_all_credentials_when_present(self):
         extract_credentials = import_module.extract_credentials
+        # InfluxDB3 normalizes headers to lowercase
         headers = {
-            "Source-Token": "token",
-            "Source-Username": "user",
-            "Source-Password": "pass",
+            "source-token": "token",
+            "source-username": "user",
+            "source-password": "pass",
         }
         result = extract_credentials(headers)
         assert result == {

--- a/influxdata/import/test_import.py
+++ b/influxdata/import/test_import.py
@@ -474,3 +474,54 @@ class TestQuerySourceInfluxdbV3Auth:
 
         with pytest.raises(ValueError, match="InfluxDB v3 requires source_token"):
             query_source_influxdb(mock_influxdb3_local, config, "SHOW MEASUREMENTS", "test-task")
+
+
+class TestExtractCredentials:
+    """Tests for extract_credentials function"""
+
+    def test_extracts_token_from_headers(self):
+        extract_credentials = import_module.extract_credentials
+        headers = {"Source-Token": "my-secret-token"}
+        result = extract_credentials(headers)
+        assert result == {
+            "source_token": "my-secret-token",
+            "source_username": None,
+            "source_password": None,
+        }
+
+    def test_extracts_username_password_from_headers(self):
+        extract_credentials = import_module.extract_credentials
+        headers = {
+            "Source-Username": "admin",
+            "Source-Password": "secret123",
+        }
+        result = extract_credentials(headers)
+        assert result == {
+            "source_token": None,
+            "source_username": "admin",
+            "source_password": "secret123",
+        }
+
+    def test_returns_none_for_missing_headers(self):
+        extract_credentials = import_module.extract_credentials
+        headers = {}
+        result = extract_credentials(headers)
+        assert result == {
+            "source_token": None,
+            "source_username": None,
+            "source_password": None,
+        }
+
+    def test_extracts_all_credentials_when_present(self):
+        extract_credentials = import_module.extract_credentials
+        headers = {
+            "Source-Token": "token",
+            "Source-Username": "user",
+            "Source-Password": "pass",
+        }
+        result = extract_credentials(headers)
+        assert result == {
+            "source_token": "token",
+            "source_username": "user",
+            "source_password": "pass",
+        }

--- a/influxdata/import/test_import.py
+++ b/influxdata/import/test_import.py
@@ -271,20 +271,18 @@ class TestCheckSourceConnection:
 class TestBuildV3Headers:
     """Tests for _build_v3_headers."""
 
-    def test_with_token_returns_bearer_auth(self):
-        result = _build_v3_headers("my-token")
-        assert result == {
+    def test_with_token(self):
+        credentials = {"source_token": "my-token", "source_username": None, "source_password": None}
+        headers = _build_v3_headers(credentials)
+        assert headers == {
             "Content-Type": "application/json",
             "Authorization": "Bearer my-token",
         }
 
-    def test_without_token_returns_content_type_only(self):
-        result = _build_v3_headers(None)
-        assert result == {"Content-Type": "application/json"}
-
-    def test_empty_token_returns_content_type_only(self):
-        result = _build_v3_headers("")
-        assert result == {"Content-Type": "application/json"}
+    def test_without_token(self):
+        credentials = {"source_token": None, "source_username": None, "source_password": None}
+        headers = _build_v3_headers(credentials)
+        assert headers == {"Content-Type": "application/json"}
 
 
 class TestParseV3Databases:

--- a/influxdata/import/test_import.py
+++ b/influxdata/import/test_import.py
@@ -361,12 +361,22 @@ class TestValidateSourceParams:
         })
         assert result == {"error": "Unsupported influxdb_version: 4. Must be 1, 2, or 3."}
 
-    def test_string_version_is_invalid(self):
+    def test_non_numeric_string_version_is_invalid(self):
         result = _validate_source_params({
             "source_url": "http://localhost:8086",
-            "influxdb_version": "3",
+            "influxdb_version": "abc",
         })
-        assert result == {"error": "Unsupported influxdb_version: 3. Must be 1, 2, or 3."}
+        assert result == {"error": "Unsupported influxdb_version: abc. Must be 1, 2, or 3."}
+
+    def test_numeric_string_version_is_coerced_to_int(self):
+        """Numeric strings like '3' should be accepted and coerced to int."""
+        body_data = {
+            "source_url": "http://localhost:8086",
+            "influxdb_version": "3",
+        }
+        result = _validate_source_params(body_data)
+        assert result is None  # Valid
+        assert body_data["influxdb_version"] == 3  # Coerced to int
 
 
 class TestGetSourceDatabasesListV3:
@@ -453,33 +463,61 @@ class TestQuerySourceInfluxdbV3Auth:
 
         mock_influxdb3_local = Mock()
 
+        # Create config WITHOUT credential fields
         config = ImportConfig(
             source_url="http://localhost",
             source_database="mydb",
             influxdb_version=3,
-            source_token="my-v3-token",
         )
 
-        query_source_influxdb(mock_influxdb3_local, config, "SHOW MEASUREMENTS", "test-task")
+        # Create credentials separately
+        credentials = {
+            "source_token": "my-v3-token",
+            "source_username": None,
+            "source_password": None,
+        }
+
+        # Pass credentials to function
+        query_source_influxdb(mock_influxdb3_local, config, credentials, "SHOW MEASUREMENTS", "test-task")
 
         # Verify the Authorization header uses Bearer format
         call_kwargs = mock_session.get.call_args
         headers = call_kwargs.kwargs.get("headers", call_kwargs[1].get("headers", {}))
         assert headers.get("Authorization") == "Bearer my-v3-token"
 
-    def test_v3_without_token_raises_error(self):
-        """Verify v3 without token raises ValueError."""
+    @patch("import.get_http_session")
+    def test_v3_without_token_no_auth_header(self, mock_get_session):
+        """Verify v3 without token results in no Authorization header."""
+        mock_session = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = {"results": [{"series": []}]}
+        mock_response.raise_for_status = Mock()
+        mock_session.get.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
         mock_influxdb3_local = Mock()
 
+        # Create config WITHOUT credential fields
         config = ImportConfig(
             source_url="http://localhost",
             source_database="mydb",
             influxdb_version=3,
-            source_token=None,
         )
 
-        with pytest.raises(ValueError, match="InfluxDB v3 requires source_token"):
-            query_source_influxdb(mock_influxdb3_local, config, "SHOW MEASUREMENTS", "test-task")
+        # Create credentials with no token
+        credentials = {
+            "source_token": None,
+            "source_username": None,
+            "source_password": None,
+        }
+
+        # Pass credentials to function
+        query_source_influxdb(mock_influxdb3_local, config, credentials, "SHOW MEASUREMENTS", "test-task")
+
+        # Verify no Authorization header is present
+        call_kwargs = mock_session.get.call_args
+        headers = call_kwargs.kwargs.get("headers", call_kwargs[1].get("headers", {}))
+        assert "Authorization" not in headers
 
 
 class TestExtractCredentials:

--- a/influxdata/import/test_import.py
+++ b/influxdata/import/test_import.py
@@ -387,7 +387,11 @@ class TestGetSourceDatabasesListV3:
             {
                 "source_url": "http://localhost:8086",
                 "influxdb_version": 3,
+            },
+            credentials={
                 "source_token": "my-token",
+                "source_username": None,
+                "source_password": None,
             },
             session=mock_session,
         )
@@ -418,7 +422,11 @@ class TestGetSourceTablesListV3:
                 "source_url": "http://localhost:8086",
                 "influxdb_version": 3,
                 "source_database": "mydb",
+            },
+            credentials={
                 "source_token": "my-token",
+                "source_username": None,
+                "source_password": None,
             },
             session=mock_session,
         )


### PR DESCRIPTION
v1/2/3 credentials only provided via http headers
credentials are not persisted

- Remove credential fields from ImportConfig and plugin metadata to avoid storing sensitive data
- Add `extract_credentials()` function to read auth from request headers at runtime
- Update all credential-dependent functions to accept credentials dict parameter
- Fix header key casing to handle InfluxDB3's lowercase normalization
- Updated readme