### PR TITLE
feat(import): Remove org requirement from v2 API functions

### DIFF
--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -3006,7 +3006,6 @@ def get_source_tables_list(
     source_url = body_data.get("source_url")
     influxdb_version = body_data.get("influxdb_version")
     source_database = body_data.get("source_database")
-    source_org = body_data.get("source_org")
 
     if not source_database:
         return {"error": "source_database is required"}

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -2947,20 +2947,18 @@ def get_source_databases_list(
 
         elif influxdb_version == 2:
             headers = _build_v2_headers(credentials)
+            headers["Content-Type"] = "application/json"
 
             response = session.get(
-                f"{base_url}/api/v2/buckets",
+                f"{base_url}/query",
+                params={"q": "SHOW DATABASES"},
                 headers=headers,
                 timeout=REQUEST_TIMEOUT_SECONDS,
             )
             response.raise_for_status()
 
-            result = response.json()
-            databases = []
-            if "buckets" in result:
-                databases = [bucket["name"] for bucket in result["buckets"]]
-
-            databases = [db for db in databases if not db.startswith("_")]
+            databases = _parse_v1_series_values(response.json())
+            databases = [db for db in databases if db not in ["_internal"]]
             return {"databases": sorted(databases)}
 
         elif influxdb_version == 3:

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -3029,37 +3029,18 @@ def get_source_tables_list(
             return {"tables": sorted(tables)}
 
         elif influxdb_version == 2:
-            if not source_org:
-                return {"error": "source_org is required for InfluxDB v2"}
+            headers = _build_v2_headers(credentials)
+            headers["Content-Type"] = "application/json"
 
-            headers = _build_v2_headers(
-                credentials,
-                extra_headers={
-                    "Content-Type": "application/vnd.flux",
-                    "Accept": "application/csv",
-                }
-            )
-
-            escaped_bucket = source_database.replace('"', '\\"')
-            flux_query = f'''import "influxdata/influxdb/schema" schema.measurements(bucket: "{escaped_bucket}")'''
-
-            response = session.post(
-                f"{base_url}/api/v2/query",
-                params={"org": source_org},
+            response = session.get(
+                f"{base_url}/query",
+                params={"db": source_database, "q": "SHOW MEASUREMENTS"},
                 headers=headers,
-                data=flux_query,
                 timeout=REQUEST_TIMEOUT_SECONDS,
             )
             response.raise_for_status()
 
-            tables = []
-            lines = response.text.strip().split("\n")
-            for line in lines[1:]:
-                if line.strip() and "," in line:
-                    parts = line.split(",")
-                    if len(parts) >= 4 and parts[3]:
-                        tables.append(parts[3].strip())
-
+            tables = _parse_v1_series_values(response.json())
             return {"tables": sorted(tables)}
 
         elif influxdb_version == 3:

--- a/influxdata/import/test_import.py
+++ b/influxdata/import/test_import.py
@@ -413,6 +413,70 @@ class TestGetSourceDatabasesListV3:
         assert call_args[1]["params"] == {"format": "json"}
 
 
+class TestGetSourceDatabasesListV2:
+    """Tests for get_source_databases_list v2 support using InfluxQL."""
+
+    def test_v2_returns_databases_using_influxql_endpoint(self):
+        """Test that v2 uses /query endpoint with SHOW DATABASES, not /api/v2/buckets."""
+        mock_session = Mock()
+        mock_response = Mock()
+        # InfluxQL response format (same as v1)
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "series": [
+                        {
+                            "name": "databases",
+                            "columns": ["name"],
+                            "values": [["mydb"], ["testdb"], ["_internal"]],
+                        }
+                    ]
+                }
+            ]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_session.get.return_value = mock_response
+
+        result = get_source_databases_list(
+            {
+                "source_url": "http://localhost:8086",
+                "influxdb_version": 2,
+                "source_token": "my-token",
+            },
+            session=mock_session,
+        )
+
+        # _internal should be filtered out
+        assert result == {"databases": ["mydb", "testdb"]}
+        mock_session.get.assert_called_once()
+        call_args = mock_session.get.call_args
+        # Verify it uses /query endpoint, not /api/v2/buckets
+        assert "/query" in call_args[0][0]
+        assert "/api/v2/buckets" not in call_args[0][0]
+        assert call_args[1]["params"] == {"q": "SHOW DATABASES"}
+
+    def test_v2_uses_token_auth_header(self):
+        """Test that v2 uses Token authorization header."""
+        mock_session = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = {"results": [{}]}
+        mock_response.raise_for_status = Mock()
+        mock_session.get.return_value = mock_response
+
+        get_source_databases_list(
+            {
+                "source_url": "http://localhost:8086",
+                "influxdb_version": 2,
+                "source_token": "my-secret-token",
+            },
+            session=mock_session,
+        )
+
+        call_args = mock_session.get.call_args
+        headers = call_args[1]["headers"]
+        assert headers.get("Authorization") == "Token my-secret-token"
+
+
 class TestGetSourceTablesListV3:
     """Tests for get_source_tables_list v3 support."""
 

--- a/influxdata/import/test_import.py
+++ b/influxdata/import/test_import.py
@@ -441,7 +441,11 @@ class TestGetSourceDatabasesListV2:
             {
                 "source_url": "http://localhost:8086",
                 "influxdb_version": 2,
+            },
+            credentials={
                 "source_token": "my-token",
+                "source_username": None,
+                "source_password": None,
             },
             session=mock_session,
         )
@@ -467,7 +471,11 @@ class TestGetSourceDatabasesListV2:
             {
                 "source_url": "http://localhost:8086",
                 "influxdb_version": 2,
+            },
+            credentials={
                 "source_token": "my-secret-token",
+                "source_username": None,
+                "source_password": None,
             },
             session=mock_session,
         )
@@ -541,8 +549,12 @@ class TestGetSourceTablesListV2:
                 "source_url": "http://localhost:8086",
                 "influxdb_version": 2,
                 "source_database": "mybucket",
-                "source_token": "my-token",
                 # Note: no source_org provided
+            },
+            credentials={
+                "source_token": "my-token",
+                "source_username": None,
+                "source_password": None,
             },
             session=mock_session,
         )
@@ -569,7 +581,11 @@ class TestGetSourceTablesListV2:
                 "source_url": "http://localhost:8086",
                 "influxdb_version": 2,
                 "source_database": "mybucket",
+            },
+            credentials={
                 "source_token": "my-token",
+                "source_username": None,
+                "source_password": None,
             },
             session=mock_session,
         )
@@ -590,7 +606,11 @@ class TestGetSourceTablesListV2:
                 "source_url": "http://localhost:8086",
                 "influxdb_version": 2,
                 "source_database": "mybucket",
+            },
+            credentials={
                 "source_token": "my-secret-token",
+                "source_username": None,
+                "source_password": None,
             },
             session=mock_session,
         )

--- a/influxdata/import/test_import.py
+++ b/influxdata/import/test_import.py
@@ -512,6 +512,94 @@ class TestGetSourceTablesListV3:
         assert call_args[1]["params"] == {"db": "mydb", "q": "SHOW TABLES", "format": "json"}
 
 
+class TestGetSourceTablesListV2:
+    """Tests for get_source_tables_list v2 support using InfluxQL."""
+
+    def test_v2_returns_tables_using_influxql_endpoint(self):
+        """Test that v2 uses /query endpoint with SHOW MEASUREMENTS, not Flux API."""
+        mock_session = Mock()
+        mock_response = Mock()
+        # InfluxQL response format (same as v1)
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "series": [
+                        {
+                            "name": "measurements",
+                            "columns": ["name"],
+                            "values": [["cpu"], ["memory"], ["disk"]],
+                        }
+                    ]
+                }
+            ]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_session.get.return_value = mock_response
+
+        result = get_source_tables_list(
+            {
+                "source_url": "http://localhost:8086",
+                "influxdb_version": 2,
+                "source_database": "mybucket",
+                "source_token": "my-token",
+                # Note: no source_org provided
+            },
+            session=mock_session,
+        )
+
+        assert result == {"tables": ["cpu", "disk", "memory"]}
+        mock_session.get.assert_called_once()
+        call_args = mock_session.get.call_args
+        # Verify it uses /query endpoint, not /api/v2/query
+        assert "/query" in call_args[0][0]
+        assert "/api/v2/query" not in call_args[0][0]
+        assert call_args[1]["params"] == {"db": "mybucket", "q": "SHOW MEASUREMENTS"}
+
+    def test_v2_does_not_require_org(self):
+        """Test that v2 works without source_org parameter."""
+        mock_session = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = {"results": [{"series": [{"values": [["test"]]}]}]}
+        mock_response.raise_for_status = Mock()
+        mock_session.get.return_value = mock_response
+
+        # Should not return an error about missing org
+        result = get_source_tables_list(
+            {
+                "source_url": "http://localhost:8086",
+                "influxdb_version": 2,
+                "source_database": "mybucket",
+                "source_token": "my-token",
+            },
+            session=mock_session,
+        )
+
+        assert "error" not in result
+        assert "tables" in result
+
+    def test_v2_uses_token_auth_header(self):
+        """Test that v2 uses Token authorization header."""
+        mock_session = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = {"results": [{}]}
+        mock_response.raise_for_status = Mock()
+        mock_session.get.return_value = mock_response
+
+        get_source_tables_list(
+            {
+                "source_url": "http://localhost:8086",
+                "influxdb_version": 2,
+                "source_database": "mybucket",
+                "source_token": "my-secret-token",
+            },
+            session=mock_session,
+        )
+
+        call_args = mock_session.get.call_args
+        headers = call_args[1]["headers"]
+        assert headers.get("Authorization") == "Token my-secret-token"
+
+
 class TestQuerySourceInfluxdbV3Auth:
     """Tests for query_source_influxdb v3 authentication."""
 


### PR DESCRIPTION
## Summary
- Replace v2 `/api/v2/buckets` endpoint with InfluxQL `/query` using `SHOW DATABASES` for `get_source_databases_list`
- Replace v2 Flux API (`/api/v2/query`) with InfluxQL `/query` using `SHOW MEASUREMENTS` for `get_source_tables_list`, removing `source_org` requirement
- Clean up unused `source_org` variable

This makes both v2 functions consistent with v1 and with how `query_source_influxdb` already handles v2 queries, using the InfluxQL compatibility endpoint with DBRP mappings and token-based auth.
