### PR TITLE
fix: use 64-bit wide types for iceberg export plugin

### DIFF
--- a/influxdata/influxdb_to_iceberg/influxdb_to_iceberg.py
+++ b/influxdata/influxdb_to_iceberg/influxdb_to_iceberg.py
@@ -76,8 +76,8 @@ from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 from pyiceberg.types import (
     BooleanType,
-    FloatType,
-    IntegerType,
+    DoubleType,
+    LongType,
     NestedField,
     PrimitiveType,
     StringType,
@@ -298,9 +298,9 @@ def generate_query(
 def pandas_dtype_to_iceberg_type(dtype) -> PrimitiveType:
     """Converts a Pandas dtype to an Iceberg type."""
     if pd.api.types.is_integer_dtype(dtype):
-        return IntegerType()
+        return LongType()
     elif pd.api.types.is_float_dtype(dtype):
-        return FloatType()
+        return DoubleType()
     elif pd.api.types.is_bool_dtype(dtype):
         return BooleanType()
     elif pd.api.types.is_datetime64_any_dtype(dtype):
@@ -364,9 +364,9 @@ def update_schema_and_dataframe(table: Table, df: pd.DataFrame, influxdb3_local,
                     break
 
             # Add column with appropriate null values based on type
-            if isinstance(field_type, IntegerType):
+            if isinstance(field_type, LongType):
                 df_modified[col_name] = pd.Series([None] * len(df_modified), dtype='Int64')
-            elif isinstance(field_type, FloatType):
+            elif isinstance(field_type, DoubleType):
                 df_modified[col_name] = pd.Series([None] * len(df_modified), dtype='float64')
             elif isinstance(field_type, BooleanType):
                 df_modified[col_name] = pd.Series([None] * len(df_modified), dtype='boolean')


### PR DESCRIPTION
## Summary

The iceberg types for float and int are 32-bit, but it should've been 64-bit. This PR changes them to use the 64-bit iceberg types.

List of types used in the plugin,

  | Usage | Pandas dtype (from InfluxDB) | Iceberg type used | Iceberg bit width | InfluxDB bit width | Correct? |
  |:--|:--|:--|:--|:--|:--|
  | `is_integer_dtype` | `int64` | `IntegerType()` | **32-bit** | 64-bit | **Wrong** → `LongType()` |
  | `is_float_dtype` | `float64` | `FloatType()` | **32-bit** | 64-bit | **Wrong** → `DoubleType()` |
  | `is_bool_dtype` | `bool` | `BooleanType()` | 1-bit | 1-bit | OK |
  | `is_datetime64_any_dtype` | `datetime64[us]` | `TimestampType()` | 64-bit (microseconds) | 64-bit (nanoseconds) | OK* |
  | `is_string_dtype` | `object`/`string` | `StringType()` | variable | variable | OK |

\* truncated to micros

