### PR TITLE
fix(import): pass credentials to generate_import_plan for dry run

### DIFF
--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -1837,6 +1837,7 @@ def resume_incomplete_import(
 def generate_import_plan(
     influxdb3_local,
     config: ImportConfig,
+    credentials: Dict[str, Optional[str]],
     import_id: str,
     measurements: List[str],
     time_estimate: Dict[str, Any],
@@ -1864,8 +1865,8 @@ def generate_import_plan(
     schema_conflicts = []
     for measurement in measurements:
         try:
-            fields = get_field_keys(influxdb3_local, config, measurement, task_id)
-            tags = get_tag_keys(influxdb3_local, config, measurement, task_id)
+            fields = get_field_keys(influxdb3_local, config, credentials, measurement, task_id)
+            tags = get_tag_keys(influxdb3_local, config, credentials, measurement, task_id)
             conflicts = check_tag_field_conflicts(tags, fields)
 
             if conflicts:
@@ -2100,6 +2101,7 @@ def _run_import(
         return generate_import_plan(
             influxdb3_local,
             config,
+            credentials,
             import_id,
             measurements,
             time_estimate,


### PR DESCRIPTION
## Summary
- `generate_import_plan` was missed during the credential refactor (c48a328) — its signature and internal calls to `get_field_keys`/`get_tag_keys` were never updated to accept and pass the `credentials` parameter
- This caused a `NameError: name 'credentials' is not defined` when running a dry run import