### PR TITLE
fix import plugin empty table status

### DIFF
--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -1391,6 +1391,15 @@ def import_table(
         influxdb3_local.info(
             f"[{task_id}] No data found in specified range for '{measurement}'"
         )
+        write_import_state(
+            influxdb3_local,
+            import_id,
+            measurement,
+            "completed",
+            0,
+            task_id,
+            no_sync=True,
+        )
         return {
             "measurement": measurement,
             "status": "completed",


### PR DESCRIPTION
If there's an empty table in the database to import, its status remains pending. This fix corrects this behavior by changing the status to completed.