### PR TITLE
Add signal generator plugin

### DIFF
--- a/influxdata/library/plugin_library.json
+++ b/influxdata/library/plugin_library.json
@@ -1,7 +1,7 @@
 {
     "plugin_library": {
         "version": "1.0.0",
-        "last_updated": "2026-05-15T15:42:04+00:00",
+        "last_updated": "2026-05-15T18:47:29+00:00",
         "plugins": [
             {
                 "name": "Downsampler",
@@ -239,6 +239,17 @@
                 "required_plugins": [],
                 "required_libraries": ["asyncua"],
                 "last_update": "2026-03-30",
+                "trigger_types_supported": ["scheduler"]
+            },
+            {
+                "name": "Signal Generator",
+                "path": "influxdata/signal_generator/signal_generator.py",
+                "description": "[BETA] Requires InfluxDB 3.8.2+. Generates configurable waveform-based time-series data on a schedule for demos, testing, dashboards, alerts, and downstream plugin validation without requiring an external data source.",
+                "author": "InfluxData",
+                "docs_file_link": "https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/signal_generator/README.md",
+                "required_plugins": [],
+                "required_libraries": [],
+                "last_update": "2026-05-15",
                 "trigger_types_supported": ["scheduler"]
             },
             {

--- a/influxdata/signal_generator/README.md
+++ b/influxdata/signal_generator/README.md
@@ -1,0 +1,496 @@
+# Signal Generator Plugin
+
+⚡ scheduled 🏷️ sample-data, demo, signal-generation, testing 🔧 InfluxDB 3 Core, InfluxDB 3 Enterprise
+
+## Description
+
+The Signal Generator Plugin lets new users produce realistic time-series data for testing InfluxDB 3 functionality and downstream plugins without needing an external data source. Generate configurable waveform signals on a schedule to test alerts, anomaly detection, threshold checks, and dashboards from the moment you start.
+
+- **Zero dependencies**: Uses Python standard library only — no packages to install
+- **Composable waveforms**: Mix sine, square, triangle, sawtooth, noise, and spike signals by stacking them
+- **Realistic signals**: Default preset produces a signal centered at 30 with a slow sine trend, Gaussian noise, and occasional large spikes — immediately useful for alert testing
+- **Gap-filling**: Generates continuous, gapless data between executions regardless of trigger schedule
+- **Flexible output**: Configure measurement name, field name, and custom tags per trigger
+
+## Important CLI limitation
+
+Trigger configurations that pass JSON values, including `waveforms` and `tags`, currently cannot be created with the `influxdb3 create trigger --trigger-arguments` CLI flag.
+The CLI splits `--trigger-arguments` on every comma, including commas inside JSON arrays and objects, so values such as `waveforms=[{"type":"spike","value":7}]` are split into invalid fragments before they reach the plugin.
+Use the InfluxDB 3 Explorer UI or the `/api/v3/configure/processing_engine_trigger` API to create configured Signal Generator triggers.
+
+The default no-argument trigger can still be created with the CLI because it does not pass JSON or comma-containing values.
+Configured examples below use the API until the CLI parsing fix is available.
+
+## Configuration
+
+Plugin parameters should be specified in the `trigger_arguments` field when creating a trigger with the API or InfluxDB 3 Explorer.
+Avoid the CLI for configured Signal Generator triggers until comma-aware parsing is available for JSON arrays and objects.
+
+### Plugin metadata
+
+This plugin includes a JSON metadata schema in its docstring that defines supported trigger types and configuration parameters. This metadata enables the [InfluxDB 3 Explorer](https://docs.influxdata.com/influxdb3/explorer/) UI to display and configure the plugin.
+
+### Optional parameters
+
+This plugin has no required parameters.
+
+| Parameter          | Type         | Default          | Description                                                                                  |
+|--------------------|--------------|------------------|----------------------------------------------------------------------------------------------|
+| `waveforms`        | JSON string  | *(default preset)* | JSON array of waveform config objects. If omitted, uses the built-in default preset.        |
+| `measurement`      | string       | `signal`         | Output measurement name.                                                                     |
+| `field`            | string       | `value`          | Output field name.                                                                           |
+| `tags`             | JSON string  | *(none)*         | Optional JSON object of tags to add to each data point. Example: `{"host": "server01"}`.    |
+| `points_per_second`| float        | `1.0`            | Data point resolution in points per second. Controls how many points are generated per second of elapsed time. |
+| `target_database`  | string       | *(none)*         | Optional target database. If omitted, writes to the trigger's own database.                 |
+
+### Waveform types
+
+Waveform configuration is supplied as a JSON array. Each object requires a `type` key; all other parameters are optional and fall back to defaults.
+
+```json
+[
+  {"type": "sine", "frequency": 0.1, "amplitude": 5.0},
+  {"type": "noise", "stddev": 0.3}
+]
+```
+
+Multiple waveforms are summed together to produce the final signal value.
+
+#### Deterministic waveforms
+
+| Type       | Parameters                                       | Defaults                                              | Notes                                              |
+|------------|--------------------------------------------------|-------------------------------------------------------|----------------------------------------------------|
+| `constant` | `value`                                          | `0.0`                                                 | Fixed y-offset; shifts the entire combined signal. |
+| `sine`     | `frequency`, `amplitude`, `offset`, `phase`      | `0.05 Hz`, `1.0`, `0.0`, `0.0`                       | 0.05 Hz = ~20 s period. Anchored to absolute time. |
+| `square`   | `frequency`, `amplitude`, `offset`, `phase`, `duty_cycle` | `0.05 Hz`, `1.0`, `0.0`, `0.0`, `0.5`   | `duty_cycle` is 0–1, fraction of period spent high.|
+| `triangle` | `frequency`, `amplitude`, `offset`, `phase`      | `0.05 Hz`, `1.0`, `0.0`, `0.0`                       | Linear ramp up then down.                          |
+| `sawtooth` | `frequency`, `amplitude`, `offset`, `phase`      | `0.05 Hz`, `1.0`, `0.0`, `0.0`                       | Linear ramp up, instant drop.                      |
+
+#### Stochastic waveforms
+
+| Type    | Parameters                                         | Defaults                              | Notes                                                                             |
+|---------|----------------------------------------------------|---------------------------------------|-----------------------------------------------------------------------------------|
+| `noise` | `stddev`, `mean`, `seed`                           | `0.1`, `0.0`, `None`                  | Gaussian noise. `seed` enables reproducible sequences.                            |
+| `spike` | `probability`, `min_amplitude`, `max_amplitude`, `seed` | `0.01`, `5.0`, `10.0`, `None`    | 1% chance of a spike per point. Magnitude drawn uniformly from `[min, max]` with random sign. |
+
+### Default preset
+
+When no `waveforms` argument is provided, the plugin uses this preset:
+
+```json
+[
+  {"type": "constant", "value": 30.0},
+  {"type": "sine", "frequency": 0.005, "amplitude": 10.0},
+  {"type": "noise", "stddev": 0.5},
+  {"type": "spike", "probability": 0.005, "min_amplitude": 8.0, "max_amplitude": 15.0}
+]
+```
+
+This produces a signal centered around 30 with a slow-moving sine wave (period ~200 s / ~3.3 minutes), light Gaussian noise (stddev 0.5), and occasional large spikes (0.5% chance per point, magnitude 8–15). Designed to be immediately useful for testing alerts and anomaly detection without any configuration.
+
+## Software Requirements
+
+- **InfluxDB 3 Core/Enterprise**: with the Processing Engine enabled
+- **Python packages**: No additional packages required (uses Python standard library only)
+
+### Installation steps
+
+1. Start InfluxDB 3 with the Processing Engine enabled (`--plugin-dir /path/to/plugins`):
+
+   ```bash
+   influxdb3 serve \
+     --node-id node0 \
+     --object-store file \
+     --data-dir ~/.influxdb3 \
+     --plugin-dir ~/.plugins
+   ```
+
+2. No additional Python packages are required for this plugin.
+
+## Trigger setup
+
+### Scheduled trigger with API configuration
+
+Use the API or InfluxDB 3 Explorer for configured triggers, especially when passing JSON values in `waveforms` or `tags`.
+
+```bash
+curl -X POST "http://localhost:8181/api/v3/configure/processing_engine_trigger" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "db": "signals",
+    "plugin_filename": "gh:influxdata/signal_generator/signal_generator.py",
+    "trigger_name": "signal_generator_trigger",
+    "trigger_specification": "every:10s",
+    "trigger_arguments": {
+      "waveforms": "[{\"type\":\"constant\",\"value\":30.0},{\"type\":\"sine\",\"frequency\":0.005,\"amplitude\":10.0},{\"type\":\"noise\",\"stddev\":0.5}]",
+      "measurement": "signal",
+      "field": "value"
+    },
+    "trigger_settings": {
+      "run_async": false,
+      "error_behavior": "log"
+    },
+    "disabled": false
+  }'
+```
+
+### Default CLI trigger
+
+The CLI can create a default no-argument trigger because no JSON value is passed.
+Do not use the CLI for `waveforms` or `tags` until the CLI parsing issue is fixed.
+
+```bash
+influxdb3 create trigger \
+  --database signals \
+  --path "gh:influxdata/signal_generator/signal_generator.py" \
+  --trigger-spec "every:10s" \
+  signal_generator_default
+```
+
+**Note:** The first execution initializes the plugin (stores the current time in cache) and does not write any data. Data begins flowing on the second execution.
+
+## Example usage
+
+### Example 1: Basic (defaults)
+
+Use the default preset with no configuration. Creates a signal centered around 30 with sine trend, noise, and spikes:
+
+```bash
+# Create the trigger
+influxdb3 create trigger \
+  --database signals \
+  --path "gh:influxdata/signal_generator/signal_generator.py" \
+  --trigger-spec "every:10s" \
+  signal_basic
+
+# Enable the trigger
+influxdb3 enable trigger --database signals signal_basic
+
+# Query signal data (after the second execution)
+influxdb3 query \
+  --database signals \
+  "SELECT time, value FROM signal ORDER BY time DESC LIMIT 10"
+```
+
+### Example 2: Custom waveforms (square + noise)
+
+Generate a square wave with added noise — useful for simulating on/off processes with sensor jitter:
+
+```bash
+curl -X POST "http://localhost:8181/api/v3/configure/processing_engine_trigger" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "db": "signals",
+    "plugin_filename": "gh:influxdata/signal_generator/signal_generator.py",
+    "trigger_name": "signal_square_noise",
+    "trigger_specification": "every:10s",
+    "trigger_arguments": {
+      "waveforms": "[{\"type\":\"square\",\"frequency\":0.02,\"amplitude\":5.0,\"duty_cycle\":0.3},{\"type\":\"noise\",\"stddev\":0.2}]"
+    },
+    "trigger_settings": {
+      "run_async": false,
+      "error_behavior": "log"
+    },
+    "disabled": false
+  }'
+```
+
+### Example 3: Custom output (measurement, field, tags)
+
+Write signal data to a specific measurement with custom field name and tags for multi-series dashboards:
+
+```bash
+curl -X POST "http://localhost:8181/api/v3/configure/processing_engine_trigger" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "db": "signals",
+    "plugin_filename": "gh:influxdata/signal_generator/signal_generator.py",
+    "trigger_name": "signal_custom_output",
+    "trigger_specification": "every:10s",
+    "trigger_arguments": {
+      "measurement": "cpu_temperature",
+      "field": "temperature",
+      "tags": "{\"host\":\"server01\",\"region\":\"us-west\"}"
+    },
+    "trigger_settings": {
+      "run_async": false,
+      "error_behavior": "log"
+    },
+    "disabled": false
+  }'
+```
+
+### Example 4: Multiple independent signals
+
+Run two triggers to generate multiple independent signals in the same database. Each trigger has its own cache and waveform configuration:
+
+```bash
+# Signal A: slow sine wave (temperature-like)
+curl -X POST "http://localhost:8181/api/v3/configure/processing_engine_trigger" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "db": "signals",
+    "plugin_filename": "gh:influxdata/signal_generator/signal_generator.py",
+    "trigger_name": "signal_temperature",
+    "trigger_specification": "every:10s",
+    "trigger_arguments": {
+      "waveforms": "[{\"type\":\"constant\",\"value\":22.0},{\"type\":\"sine\",\"frequency\":0.002,\"amplitude\":3.0},{\"type\":\"noise\",\"stddev\":0.1}]",
+      "measurement": "environment",
+      "field": "temperature",
+      "tags": "{\"sensor\":\"A\"}"
+    },
+    "trigger_settings": {
+      "run_async": false,
+      "error_behavior": "log"
+    },
+    "disabled": false
+  }'
+
+# Signal B: faster oscillation with spikes (pressure-like)
+curl -X POST "http://localhost:8181/api/v3/configure/processing_engine_trigger" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "db": "signals",
+    "plugin_filename": "gh:influxdata/signal_generator/signal_generator.py",
+    "trigger_name": "signal_pressure",
+    "trigger_specification": "every:10s",
+    "trigger_arguments": {
+      "waveforms": "[{\"type\":\"constant\",\"value\":101.3},{\"type\":\"sine\",\"frequency\":0.01,\"amplitude\":0.8},{\"type\":\"spike\",\"probability\":0.01,\"min_amplitude\":2.0,\"max_amplitude\":5.0}]",
+      "measurement": "environment",
+      "field": "pressure",
+      "tags": "{\"sensor\":\"B\"}"
+    },
+    "trigger_settings": {
+      "run_async": false,
+      "error_behavior": "log"
+    },
+    "disabled": false
+  }'
+```
+
+### Waveform JSON examples
+
+#### Single sine wave (all defaults)
+
+```json
+[{"type": "sine"}]
+```
+
+Produces a sine at 0.05 Hz (20 s period), amplitude 1.0, centered at 0.
+
+#### Combined sine and noise
+
+```json
+[
+  {"type": "constant", "value": 50.0},
+  {"type": "sine", "frequency": 0.01, "amplitude": 15.0},
+  {"type": "noise", "stddev": 1.0}
+]
+```
+
+Produces a signal centered at 50 with a 100 s period sine (±15) and moderate noise.
+
+#### Square wave with custom duty cycle
+
+```json
+[
+  {"type": "square", "frequency": 0.05, "amplitude": 10.0, "duty_cycle": 0.25}
+]
+```
+
+Produces a square wave spending 25% of each period at +10 and 75% at -10.
+
+#### Full custom signal
+
+```json
+[
+  {"type": "constant", "value": 100.0},
+  {"type": "triangle", "frequency": 0.005, "amplitude": 20.0},
+  {"type": "noise", "stddev": 2.0},
+  {"type": "spike", "probability": 0.02, "min_amplitude": 30.0, "max_amplitude": 60.0}
+]
+```
+
+Produces a triangle wave centered at 100, with 2% spike probability and magnitude 30–60.
+
+## Output schema
+
+### Measurement: `signal` (default, configurable)
+
+**Tags:**
+
+Tags are optional and have no defaults. Tags are only present when specified via the `tags` trigger argument.
+
+Example with `tags={"host": "server01", "region": "us-west"}`:
+- `host`: `server01`
+- `region`: `us-west`
+
+**Fields:**
+
+- `value` (float64): The computed signal value at each timestamp. Field name is configurable via the `field` argument.
+
+**Timestamp:**
+
+- Nanosecond precision Unix epoch timestamps. Each point's timestamp reflects the exact simulated time, not the wall-clock time of the write.
+
+### Line protocol examples
+
+Without tags (default):
+
+```
+signal value=32.47 1712678400000000000
+signal value=31.89 1712678401000000000
+signal value=33.21 1712678402000000000
+```
+
+With custom measurement, field, and tags:
+
+```
+cpu_temperature,host=server01,region=us-west temperature=72.3 1712678400000000000
+cpu_temperature,host=server01,region=us-west temperature=71.8 1712678401000000000
+```
+
+## Example queries
+
+### View the most recent signal values
+
+```sql
+SELECT time, value
+FROM signal
+WHERE time > now() - INTERVAL '5 minutes'
+ORDER BY time DESC
+LIMIT 20;
+```
+
+### Compute rolling statistics
+
+```sql
+SELECT
+  time_bucket(time, INTERVAL '1 minute') AS minute,
+  AVG(value) AS avg_value,
+  MIN(value) AS min_value,
+  MAX(value) AS max_value
+FROM signal
+WHERE time > now() - INTERVAL '1 hour'
+GROUP BY minute
+ORDER BY minute DESC;
+```
+
+### Find spikes (values far from the mean)
+
+```sql
+SELECT time, value
+FROM signal
+WHERE time > now() - INTERVAL '1 hour'
+  AND ABS(value - 30.0) > 10.0
+ORDER BY time DESC;
+```
+
+### Compare multiple signals
+
+```sql
+SELECT time, temperature, pressure
+FROM environment
+WHERE time > now() - INTERVAL '30 minutes'
+ORDER BY time DESC
+LIMIT 50;
+```
+
+## Code overview
+
+### Files
+
+- `signal_generator.py`: The main plugin code containing all waveform factories, config parsing, time series generation, and the scheduled trigger entry point.
+
+### Main functions
+
+#### `process_scheduled_call(influxdb3_local, call_time, args)`
+
+Entry point for scheduled triggers. Orchestrates the full execution: parses config, reads the cache, generates timestamps and signal values, writes points, and updates the cache.
+
+Key operations:
+
+1. Parses waveform, output, and resolution configuration from trigger arguments
+2. Reads `last_time` from the trigger-local cache
+3. On first run: stores current time and returns without writing (initialization)
+4. Generates timestamps in the half-open interval `(last_time, now]`
+5. Evaluates the combined waveform at each timestamp
+6. Writes all points using `write_sync` with `no_sync=True`
+7. Updates `last_time` in the cache
+
+#### Waveform factories
+
+`make_constant`, `make_sine`, `make_square`, `make_triangle`, `make_sawtooth`, `make_noise`, `make_spike` — each returns a function `f(t: float) -> float` where `t` is Unix epoch seconds. Deterministic waveforms are anchored to absolute time (same `t` always produces the same value). Stochastic waveforms draw from a `random.Random` instance per factory call.
+
+#### `combine(waveform_fns)`
+
+Composes a list of waveform functions by summing their outputs: `combined(t) = sum(fn(t) for fn in waveform_fns)`.
+
+#### `generate_timestamps(start, end, points_per_second)`
+
+Generates timestamps in the half-open interval `(start, end]`. The interval is exclusive of `start` to prevent duplicate points across consecutive executions.
+
+## Troubleshooting
+
+### Common issues
+
+#### Issue: No data appearing after enabling the trigger
+
+**Cause**: The first execution initializes the plugin (stores the current time) and does not write any data. This is by design.
+
+**Solution**: Wait for the second execution. Check the logs to confirm initialization succeeded:
+
+```bash
+influxdb3 query \
+  --database signals \
+  "SELECT * FROM system.processing_engine_logs WHERE trigger_name = 'signal_basic' ORDER BY event_time DESC LIMIT 5"
+```
+
+Look for a log entry containing `"Signal generator initializing"` — this confirms the first run completed successfully and data will appear on the next execution.
+
+#### Issue: Config parsing error in logs
+
+**Cause**: Malformed JSON in `waveforms` or `tags` arguments, or an unknown waveform type.
+
+**Solution**: Validate your JSON before passing it as a trigger argument. Supported waveform types are: `constant`, `sine`, `square`, `triangle`, `sawtooth`, `noise`, `spike`. Check for typos and ensure the JSON array is valid:
+
+```bash
+# Validate JSON locally
+echo '[{"type": "sine"}, {"type": "noise"}]' | python3 -m json.tool
+```
+
+#### Issue: No points generated (interval too short)
+
+**Cause**: The trigger fires more frequently than `1 / points_per_second` seconds, so no timestamps fall in the interval.
+
+**Solution**: Increase `points_per_second` to match your trigger frequency, or reduce trigger frequency. For example, if firing every 1 s with `points_per_second=1.0`, at least one point is generated per execution. If firing every 100ms, increase to `points_per_second=10.0`.
+
+#### Issue: Write failures for individual points
+
+**Cause**: Intermittent write errors. The plugin logs each failed point and continues.
+
+**Solution**: Check logs for write error details:
+
+```bash
+influxdb3 query \
+  --database signals \
+  "SELECT * FROM system.processing_engine_logs WHERE trigger_name = 'signal_basic' AND log_text LIKE '%Write failed%' ORDER BY event_time DESC LIMIT 10"
+```
+
+#### Issue: Signal is not phase-continuous after restart
+
+**Cause**: Deterministic waveforms (sine, square, triangle, sawtooth) are anchored to absolute Unix time, so they are always at the correct phase for a given wall-clock time. If the signal appears discontinuous, check that the `frequency` parameter is the same before and after the restart.
+
+**Cause of gaps in data**: If the trigger was disabled or InfluxDB was stopped, the cache retains `last_time` from the last successful execution. On restart, the plugin generates all missing points from `last_time` to the current time, filling the gap automatically.
+
+### Viewing logs
+
+```bash
+influxdb3 query \
+  --database YOUR_DATABASE \
+  "SELECT * FROM system.processing_engine_logs WHERE trigger_name = 'signal_basic' ORDER BY event_time DESC LIMIT 20"
+```
+
+## Questions/Comments
+
+For additional support, see the [Support section](../README.md#support).

--- a/influxdata/signal_generator/signal_generator.py
+++ b/influxdata/signal_generator/signal_generator.py
@@ -1,0 +1,403 @@
+"""
+{
+    "plugin_type": ["scheduled"],
+    "scheduled_args_config": [
+        {
+            "name": "waveforms",
+            "example": "[{\"type\": \"sine\"}, {\"type\": \"noise\", \"stddev\": 0.3}]",
+            "description": "JSON array of waveform config objects. Each object has a 'type' key and optional parameter overrides. Supported types: constant, sine, square, triangle, sawtooth, noise, spike.",
+            "required": false
+        },
+        {
+            "name": "measurement",
+            "example": "signal",
+            "description": "Output measurement name. Defaults to 'signal'.",
+            "required": false
+        },
+        {
+            "name": "field",
+            "example": "value",
+            "description": "Output field name. Defaults to 'value'.",
+            "required": false
+        },
+        {
+            "name": "tags",
+            "example": "{\"host\": \"server01\"}",
+            "description": "Optional JSON object of tags to add to each data point.",
+            "required": false
+        },
+        {
+            "name": "points_per_second",
+            "example": "1.0",
+            "description": "Data point resolution in points per second. Defaults to 1.0.",
+            "required": false
+        },
+        {
+            "name": "target_database",
+            "example": "my_db",
+            "description": "Optional target database. If omitted, writes to the trigger's database.",
+            "required": false
+        }
+    ]
+}
+"""
+
+import math
+import json
+import random
+import uuid
+from typing import Iterable, Optional, Protocol, runtime_checkable
+
+# LineBuilder is injected by the InfluxDB 3 Processing Engine runtime.
+# The stub below allows tests to monkeypatch it.
+try:
+    LineBuilder = LineBuilder  # noqa: F821 — already in scope when injected
+except NameError:
+    LineBuilder = None  # type: ignore[assignment,misc]
+
+
+# ---------------------------------------------------------------------------
+# Waveform factories
+# ---------------------------------------------------------------------------
+
+def make_constant(value=0.0):
+    def waveform(t):
+        return value
+    return waveform
+
+
+def make_sine(frequency=0.05, amplitude=1.0, offset=0.0, phase=0.0):
+    def waveform(t):
+        return offset + amplitude * math.sin(2 * math.pi * frequency * t + phase)
+    return waveform
+
+
+def make_square(frequency=0.05, amplitude=1.0, offset=0.0, phase=0.0, duty_cycle=0.5):
+    def waveform(t):
+        cycle_position = (frequency * t + phase / (2 * math.pi)) % 1.0
+        if cycle_position < duty_cycle:
+            return offset + amplitude
+        else:
+            return offset - amplitude
+    return waveform
+
+
+def make_triangle(frequency=0.05, amplitude=1.0, offset=0.0, phase=0.0):
+    def waveform(t):
+        cycle_position = (frequency * t + phase / (2 * math.pi)) % 1.0
+        if cycle_position < 0.5:
+            return offset + amplitude * (4 * cycle_position - 1)
+        else:
+            return offset + amplitude * (3 - 4 * cycle_position)
+    return waveform
+
+
+def make_sawtooth(frequency=0.05, amplitude=1.0, offset=0.0, phase=0.0):
+    def waveform(t):
+        cycle_position = (frequency * t + phase / (2 * math.pi)) % 1.0
+        return offset + amplitude * (2 * cycle_position - 1)
+    return waveform
+
+
+def make_noise(stddev=0.1, mean=0.0, seed=None):
+    rng = random.Random(seed)
+    def waveform(t):
+        return rng.gauss(mean, stddev)
+    return waveform
+
+
+def make_spike(probability=0.01, min_amplitude=5.0, max_amplitude=10.0, seed=None):
+    rng = random.Random(seed)
+    def waveform(t):
+        if rng.random() < probability:
+            magnitude = rng.uniform(min_amplitude, max_amplitude)
+            sign = rng.choice([-1, 1])
+            return sign * magnitude
+        return 0.0
+    return waveform
+
+
+def combine(waveform_fns):
+    def combined(t):
+        return sum(fn(t) for fn in waveform_fns)
+    return combined
+
+
+# ---------------------------------------------------------------------------
+# Waveform registry and default preset
+# ---------------------------------------------------------------------------
+
+WAVEFORM_REGISTRY = {
+    "constant": make_constant,
+    "sine": make_sine,
+    "square": make_square,
+    "triangle": make_triangle,
+    "sawtooth": make_sawtooth,
+    "noise": make_noise,
+    "spike": make_spike,
+}
+
+PARAM_CONSTRAINTS = {
+    "frequency": lambda v: v >= 0,
+    "amplitude": lambda v: v >= 0,
+    "stddev": lambda v: v >= 0,
+    "probability": lambda v: 0 <= v <= 1,
+    "duty_cycle": lambda v: 0 <= v <= 1,
+    "min_amplitude": lambda v: v >= 0,
+    "max_amplitude": lambda v: v >= 0,
+}
+
+
+def _validate_params(params):
+    for key, value in params.items():
+        check = PARAM_CONSTRAINTS.get(key)
+        if check is not None and not check(value):
+            return False
+    if "min_amplitude" in params and "max_amplitude" in params:
+        if params["min_amplitude"] > params["max_amplitude"]:
+            return False
+    return True
+
+DEFAULT_WAVEFORMS = [
+    {"type": "constant", "value": 30.0},
+    {"type": "sine", "frequency": 0.005, "amplitude": 10.0},
+    {"type": "noise", "stddev": 0.5},
+    {"type": "spike", "probability": 0.005, "min_amplitude": 8.0, "max_amplitude": 15.0},
+]
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+def parse_waveform_config(waveforms_json):
+    """Parse waveforms JSON string into a list of waveform functions.
+    Returns None on error (caller should log and return early).
+    """
+    if waveforms_json is None:
+        waveform_configs = DEFAULT_WAVEFORMS
+    else:
+        try:
+            waveform_configs = json.loads(waveforms_json)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    if not isinstance(waveform_configs, list):
+        return None
+
+    fns = []
+    for config in waveform_configs:
+        waveform_type = config.get("type")
+        if waveform_type is None:
+            return None
+
+        factory = WAVEFORM_REGISTRY.get(waveform_type)
+        if factory is None:
+            return None
+
+        params = {k: v for k, v in config.items() if k != "type"}
+        if not _validate_params(params):
+            return None
+        try:
+            fns.append(factory(**params))
+        except TypeError:
+            return None
+
+    return fns
+
+
+def parse_output_config(args):
+    """Parse output configuration from trigger args.
+    Returns (measurement, field, tags_dict, target_database) or None on error.
+    """
+    if args is None:
+        args = {}
+
+    measurement = args.get("measurement", "signal")
+    field = args.get("field", "value")
+    target_database = args.get("target_database", None)
+
+    tags_json = args.get("tags", None)
+    if tags_json is not None:
+        try:
+            tags = json.loads(tags_json)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    else:
+        tags = {}
+
+    return (measurement, field, tags, target_database)
+
+
+def parse_points_per_second(args):
+    """Parse points_per_second from trigger args.
+    Returns float or None on error.
+    """
+    if args is None:
+        return 1.0
+    raw = args.get("points_per_second", "1.0")
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        return None
+    if value <= 0:
+        return None
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Time series generation
+# ---------------------------------------------------------------------------
+
+def generate_timestamps(start, end, points_per_second):
+    """Generate timestamps in the half-open interval (start, end].
+    Returns a list of floats (Unix epoch seconds).
+    """
+    interval = 1.0 / points_per_second
+    timestamps = []
+    t = start + interval
+    while t <= end + (interval * 1e-9):  # tiny epsilon for float comparison
+        timestamps.append(t)
+        t += interval
+    return timestamps
+
+
+def generate_signal(waveform_fn, timestamps):
+    """Evaluate a waveform function at each timestamp.
+    Returns a list of (timestamp, value) tuples.
+    """
+    return [(t, waveform_fn(t)) for t in timestamps]
+
+
+# ---------------------------------------------------------------------------
+# Batch write helper
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class _LineBuilderInterface(Protocol):
+    def build(self) -> str: ...
+
+
+class _BatchLines:
+    """Wraps multiple LineBuilder objects into a single object with a build()
+    method that returns a newline-separated string. This allows batched writes
+    through the write_sync / write_sync_to_db APIs."""
+
+    def __init__(self, line_builders: Iterable[_LineBuilderInterface]):
+        self._line_builders = list(line_builders)
+        self._built: Optional[str] = None
+
+    def _coerce_builder(self, builder: _LineBuilderInterface) -> str:
+        build_fn = getattr(builder, "build", None)
+        if not callable(build_fn):
+            raise TypeError("line_builder is missing a callable build()")
+        return str(build_fn())
+
+    def build(self) -> str:
+        if self._built is None:
+            lines = [self._coerce_builder(b) for b in self._line_builders]
+            if not lines:
+                raise ValueError("batch_write received no lines to build")
+            self._built = "\n".join(lines)
+        return self._built
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+def build_line(measurement, field, value, tags, timestamp_ns):
+    """Build a single LineBuilder for one data point."""
+    line = LineBuilder(measurement)
+    for tag_key, tag_value in tags.items():
+        line.tag(tag_key, str(tag_value))
+    line.float64_field(field, value)
+    line.time_ns(timestamp_ns)
+    return line
+
+
+def write_points(influxdb3_local, points, measurement, field, tags, target_database):
+    """Build LineBuilder objects for all points and write as a single batch."""
+    line_builders = []
+    for t, value in points:
+        line = build_line(measurement, field, value, tags, int(t * 1_000_000_000))
+        line_builders.append(line)
+
+    if not line_builders:
+        return 0
+
+    batch = _BatchLines(line_builders)
+    if target_database:
+        influxdb3_local.write_sync_to_db(target_database, batch, no_sync=True)
+    else:
+        influxdb3_local.write_sync(batch, no_sync=True)
+    return len(line_builders)
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+CACHE_KEY = "signal_gen:last_time"
+
+
+def get_last_time(cache):
+    return cache.get(CACHE_KEY)
+
+
+def set_last_time(cache, t):
+    cache.put(CACHE_KEY, t)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def process_scheduled_call(influxdb3_local, call_time, args=None):
+    task_id = str(uuid.uuid4())[:8]
+
+    now = call_time.timestamp()
+
+    # --- Parse config ---
+    waveforms_json = args.get("waveforms", None) if args else None
+    waveform_fns = parse_waveform_config(waveforms_json)
+    if waveform_fns is None:
+        influxdb3_local.error(f"[{task_id}] Failed to parse waveform config")
+        return
+
+    output_config = parse_output_config(args)
+    if output_config is None:
+        influxdb3_local.error(f"[{task_id}] Failed to parse output config")
+        return
+    measurement, field, tags, target_database = output_config
+
+    pps = parse_points_per_second(args)
+    if pps is None:
+        influxdb3_local.error(f"[{task_id}] Failed to parse points_per_second")
+        return
+
+    # --- Check cache for last execution time ---
+    last_time = get_last_time(influxdb3_local.cache)
+    if last_time is None:
+        influxdb3_local.info(f"[{task_id}] Signal generator initializing, first data on next execution")
+        set_last_time(influxdb3_local.cache, now)
+        return
+
+    # --- Generate and write data ---
+    combined = combine(waveform_fns)
+    timestamps = generate_timestamps(last_time, now, pps)
+
+    if not timestamps:
+        influxdb3_local.info(f"[{task_id}] No points to generate (interval too short)")
+        set_last_time(influxdb3_local.cache, now)
+        return
+
+    points = generate_signal(combined, timestamps)
+
+    try:
+        written = write_points(influxdb3_local, points, measurement, field, tags, target_database)
+        influxdb3_local.info(f"[{task_id}] Wrote {written} points to {measurement}.{field}")
+    except Exception as e:
+        influxdb3_local.error(f"[{task_id}] Batch write failed: {e}")
+
+    set_last_time(influxdb3_local.cache, now)

--- a/influxdata/signal_generator/test_signal_generator.py
+++ b/influxdata/signal_generator/test_signal_generator.py
@@ -1,0 +1,692 @@
+"""
+Unit tests for the Signal Generator Plugin.
+"""
+
+import math
+import json
+import sys
+import os
+
+
+# ---------------------------------------------------------------------------
+# Mocks for the InfluxDB 3 Processing Engine runtime
+# ---------------------------------------------------------------------------
+
+class MockLineBuilder:
+    """Simulates the LineBuilder class injected by the processing engine."""
+    def __init__(self, measurement):
+        self.measurement = measurement
+        self.tags_list = []
+        self.fields_list = []
+        self.timestamp = None
+
+    def tag(self, key, value):
+        self.tags_list.append((key, str(value)))
+        return self
+
+    def float64_field(self, key, value):
+        self.fields_list.append((key, float(value)))
+        return self
+
+    def time_ns(self, ts):
+        self.timestamp = ts
+        return self
+
+    def build(self):
+        parts = [self.measurement]
+        if self.tags_list:
+            tag_str = ",".join(f"{k}={v}" for k, v in self.tags_list)
+            parts[0] = f"{self.measurement},{tag_str}"
+        field_strs = [f"{k}={v}" for k, v in self.fields_list]
+        parts.append(",".join(field_strs))
+        if self.timestamp is not None:
+            parts.append(str(self.timestamp))
+        return " ".join(parts)
+
+
+class MockCache:
+    """Simulates the influxdb3_local.cache object."""
+    def __init__(self):
+        self._store = {}
+
+    def get(self, key, default=None):
+        return self._store.get(key, default)
+
+    def put(self, key, value, ttl=None):
+        self._store[key] = value
+
+    def clear(self):
+        self._store.clear()
+
+
+class MockInfluxDB3Local:
+    """Simulates the influxdb3_local object passed to process_scheduled_call."""
+    def __init__(self):
+        self.cache = MockCache()
+        self.written_lines = []
+        self.written_to_db = []
+        self.logs = {"info": [], "warn": [], "error": []}
+
+    def write_sync(self, line, no_sync=False):
+        self.written_lines.append(line)
+
+    def write_sync_to_db(self, db_name, line, no_sync=False):
+        self.written_to_db.append((db_name, line))
+
+    def info(self, *args):
+        self.logs["info"].append(" ".join(str(a) for a in args))
+
+    def warn(self, *args):
+        self.logs["warn"].append(" ".join(str(a) for a in args))
+
+    def error(self, *args):
+        self.logs["error"].append(" ".join(str(a) for a in args))
+
+    def reset(self):
+        self.written_lines.clear()
+        self.written_to_db.clear()
+        self.logs = {"info": [], "warn": [], "error": []}
+        self.cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Waveform factory tests
+# ---------------------------------------------------------------------------
+
+def test_make_constant_default():
+    from signal_generator import make_constant
+    fn = make_constant()
+    assert fn(0.0) == 0.0
+    assert fn(100.0) == 0.0
+    assert fn(-50.0) == 0.0
+
+
+def test_make_constant_custom_value():
+    from signal_generator import make_constant
+    fn = make_constant(value=30.0)
+    assert fn(0.0) == 30.0
+    assert fn(999.9) == 30.0
+
+
+def test_make_sine_default_at_zero():
+    from signal_generator import make_sine
+    fn = make_sine()
+    assert fn(0.0) == 0.0
+
+def test_make_sine_default_period():
+    from signal_generator import make_sine
+    fn = make_sine()
+    assert abs(fn(5.0) - 1.0) < 1e-10
+
+def test_make_sine_custom_params():
+    from signal_generator import make_sine
+    fn = make_sine(frequency=1.0, amplitude=5.0, offset=10.0, phase=0.0)
+    assert abs(fn(0.25) - 15.0) < 1e-10
+
+def test_make_sine_with_offset():
+    from signal_generator import make_sine
+    fn = make_sine(offset=100.0)
+    assert fn(0.0) == 100.0
+
+def test_make_sine_is_deterministic():
+    from signal_generator import make_sine
+    fn = make_sine()
+    t = 12345.6789
+    assert fn(t) == fn(t)
+
+
+def test_make_square_default_first_half():
+    from signal_generator import make_square
+    fn = make_square()
+    assert fn(0.0) == 1.0
+    assert fn(5.0) == 1.0
+
+def test_make_square_default_second_half():
+    from signal_generator import make_square
+    fn = make_square()
+    assert fn(10.0) == -1.0
+    assert fn(15.0) == -1.0
+
+def test_make_square_custom_duty_cycle():
+    from signal_generator import make_square
+    fn = make_square(frequency=1.0, duty_cycle=0.25)
+    assert fn(0.0) == 1.0
+    assert fn(0.1) == 1.0
+    assert fn(0.3) == -1.0
+    assert fn(0.9) == -1.0
+
+def test_make_square_with_offset():
+    from signal_generator import make_square
+    fn = make_square(offset=5.0)
+    assert fn(0.0) == 6.0
+    assert fn(10.0) == 4.0
+
+
+def test_make_triangle_default_start():
+    from signal_generator import make_triangle
+    fn = make_triangle()
+    assert abs(fn(0.0) - (-1.0)) < 1e-10
+
+def test_make_triangle_default_quarter():
+    from signal_generator import make_triangle
+    fn = make_triangle()
+    assert abs(fn(5.0) - 0.0) < 1e-10
+
+def test_make_triangle_default_half():
+    from signal_generator import make_triangle
+    fn = make_triangle()
+    assert abs(fn(10.0) - 1.0) < 1e-10
+
+def test_make_triangle_default_three_quarter():
+    from signal_generator import make_triangle
+    fn = make_triangle()
+    assert abs(fn(15.0) - 0.0) < 1e-10
+
+def test_make_triangle_custom_amplitude():
+    from signal_generator import make_triangle
+    fn = make_triangle(frequency=1.0, amplitude=10.0)
+    assert abs(fn(0.25) - 0.0) < 1e-10
+    assert abs(fn(0.5) - 10.0) < 1e-10
+
+
+def test_make_sawtooth_default_start():
+    from signal_generator import make_sawtooth
+    fn = make_sawtooth()
+    assert abs(fn(0.0) - (-1.0)) < 1e-10
+
+def test_make_sawtooth_default_half():
+    from signal_generator import make_sawtooth
+    fn = make_sawtooth()
+    assert abs(fn(10.0) - 0.0) < 1e-10
+
+def test_make_sawtooth_default_near_end():
+    from signal_generator import make_sawtooth
+    fn = make_sawtooth()
+    assert abs(fn(19.0) - 0.9) < 1e-10
+
+def test_make_sawtooth_custom_amplitude():
+    from signal_generator import make_sawtooth
+    fn = make_sawtooth(frequency=1.0, amplitude=5.0, offset=10.0)
+    assert abs(fn(0.5) - 10.0) < 1e-10
+    assert abs(fn(0.75) - 12.5) < 1e-10
+
+
+def test_make_noise_returns_float():
+    from signal_generator import make_noise
+    fn = make_noise(seed=42)
+    result = fn(0.0)
+    assert isinstance(result, float)
+
+def test_make_noise_seeded_produces_sequence():
+    from signal_generator import make_noise
+    fn = make_noise(seed=42)
+    values = [fn(i) for i in range(10)]
+    fn2 = make_noise(seed=42)
+    values2 = [fn2(i) for i in range(10)]
+    assert values == values2
+
+def test_make_noise_unseeded_varies():
+    from signal_generator import make_noise
+    fn1 = make_noise()
+    fn2 = make_noise()
+    vals1 = [fn1(i) for i in range(100)]
+    vals2 = [fn2(i) for i in range(100)]
+    assert vals1 != vals2
+
+def test_make_noise_mean_and_stddev():
+    from signal_generator import make_noise
+    fn = make_noise(mean=10.0, stddev=1.0, seed=42)
+    samples = [fn(i) for i in range(10000)]
+    sample_mean = sum(samples) / len(samples)
+    assert abs(sample_mean - 10.0) < 0.1
+
+
+def test_make_spike_zero_probability():
+    from signal_generator import make_spike
+    fn = make_spike(probability=0.0, seed=42)
+    values = [fn(i) for i in range(1000)]
+    assert all(v == 0.0 for v in values)
+
+def test_make_spike_full_probability():
+    from signal_generator import make_spike
+    fn = make_spike(probability=1.0, min_amplitude=5.0, max_amplitude=10.0, seed=42)
+    values = [fn(i) for i in range(100)]
+    assert all(v != 0.0 for v in values)
+    assert all(5.0 <= abs(v) <= 10.0 for v in values)
+
+def test_make_spike_produces_positive_and_negative():
+    from signal_generator import make_spike
+    fn = make_spike(probability=1.0, min_amplitude=5.0, max_amplitude=10.0, seed=42)
+    values = [fn(i) for i in range(100)]
+    has_positive = any(v > 0 for v in values)
+    has_negative = any(v < 0 for v in values)
+    assert has_positive and has_negative
+
+def test_make_spike_seeded_reproducible():
+    from signal_generator import make_spike
+    fn1 = make_spike(probability=0.5, seed=42)
+    fn2 = make_spike(probability=0.5, seed=42)
+    vals1 = [fn1(i) for i in range(50)]
+    vals2 = [fn2(i) for i in range(50)]
+    assert vals1 == vals2
+
+
+# ---------------------------------------------------------------------------
+# Composition tests
+# ---------------------------------------------------------------------------
+
+def test_combine_sums_waveforms():
+    from signal_generator import combine, make_constant
+    fn = combine([make_constant(10.0), make_constant(20.0)])
+    assert fn(0.0) == 30.0
+
+def test_combine_empty_list():
+    from signal_generator import combine
+    fn = combine([])
+    assert fn(0.0) == 0.0
+
+def test_combine_single_waveform():
+    from signal_generator import combine, make_constant
+    fn = combine([make_constant(5.0)])
+    assert fn(0.0) == 5.0
+
+def test_combine_sine_and_constant():
+    from signal_generator import combine, make_sine, make_constant
+    fn = combine([make_constant(100.0), make_sine(frequency=1.0, amplitude=1.0)])
+    assert abs(fn(0.0) - 100.0) < 1e-10
+    assert abs(fn(0.25) - 101.0) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+def test_waveform_registry_has_all_types():
+    from signal_generator import WAVEFORM_REGISTRY
+    expected = {"constant", "sine", "square", "triangle", "sawtooth", "noise", "spike"}
+    assert set(WAVEFORM_REGISTRY.keys()) == expected
+
+
+def test_default_waveforms_is_list():
+    from signal_generator import DEFAULT_WAVEFORMS
+    assert isinstance(DEFAULT_WAVEFORMS, list)
+    assert len(DEFAULT_WAVEFORMS) > 0
+
+
+def test_default_waveforms_types_are_valid():
+    from signal_generator import DEFAULT_WAVEFORMS, WAVEFORM_REGISTRY
+    for wf in DEFAULT_WAVEFORMS:
+        assert "type" in wf
+        assert wf["type"] in WAVEFORM_REGISTRY
+
+
+# ---------------------------------------------------------------------------
+# Config parsing tests
+# ---------------------------------------------------------------------------
+
+def test_parse_waveform_config_default():
+    from signal_generator import parse_waveform_config
+    fns = parse_waveform_config(None)
+    assert len(fns) == 4
+    assert all(callable(fn) for fn in fns)
+
+
+def test_parse_waveform_config_json_string():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "sine"}, {"type": "constant", "value": 5.0}])
+    fns = parse_waveform_config(config)
+    assert len(fns) == 2
+
+
+def test_parse_waveform_config_unknown_type():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "unknown_wave"}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_bad_json():
+    from signal_generator import parse_waveform_config
+    result = parse_waveform_config("not valid json")
+    assert result is None
+
+
+def test_parse_waveform_config_missing_type():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"frequency": 0.1}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_invalid_params():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "sine", "bogus_param": 1}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_negative_frequency():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "sine", "frequency": -1.0}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_negative_amplitude():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "sine", "amplitude": -5.0}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_negative_stddev():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "noise", "stddev": -0.5}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_probability_above_one():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "spike", "probability": 1.5}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_negative_probability():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "spike", "probability": -0.1}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_duty_cycle_out_of_range():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "square", "duty_cycle": 1.5}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_waveform_config_spike_min_greater_than_max():
+    from signal_generator import parse_waveform_config
+    config = json.dumps([{"type": "spike", "min_amplitude": 10.0, "max_amplitude": 5.0}])
+    result = parse_waveform_config(config)
+    assert result is None
+
+
+def test_parse_output_config_defaults():
+    from signal_generator import parse_output_config
+    result = parse_output_config(None)
+    assert result == ("signal", "value", {}, None)
+
+
+def test_parse_output_config_custom():
+    from signal_generator import parse_output_config
+    args = {
+        "measurement": "cpu_temp",
+        "field": "temperature",
+        "tags": '{"host": "server01", "location": "dc1"}',
+        "target_database": "my_db",
+    }
+    result = parse_output_config(args)
+    assert result == ("cpu_temp", "temperature", {"host": "server01", "location": "dc1"}, "my_db")
+
+
+def test_parse_output_config_no_tags():
+    from signal_generator import parse_output_config
+    args = {"measurement": "test"}
+    result = parse_output_config(args)
+    assert result == ("test", "value", {}, None)
+
+
+def test_parse_output_config_bad_tags_json():
+    from signal_generator import parse_output_config
+    args = {"tags": "not json"}
+    result = parse_output_config(args)
+    assert result is None
+
+
+def test_parse_points_per_second_default():
+    from signal_generator import parse_points_per_second
+    assert parse_points_per_second(None) == 1.0
+
+
+def test_parse_points_per_second_custom():
+    from signal_generator import parse_points_per_second
+    assert parse_points_per_second({"points_per_second": "10"}) == 10.0
+
+
+def test_parse_points_per_second_invalid():
+    from signal_generator import parse_points_per_second
+    result = parse_points_per_second({"points_per_second": "abc"})
+    assert result is None
+
+
+def test_parse_points_per_second_zero():
+    from signal_generator import parse_points_per_second
+    result = parse_points_per_second({"points_per_second": "0"})
+    assert result is None
+
+
+def test_parse_points_per_second_negative():
+    from signal_generator import parse_points_per_second
+    result = parse_points_per_second({"points_per_second": "-5"})
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Time series generation tests
+# ---------------------------------------------------------------------------
+
+def test_generate_timestamps_basic():
+    from signal_generator import generate_timestamps
+    ts = generate_timestamps(0.0, 5.0, 1.0)
+    assert ts == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+
+def test_generate_timestamps_high_resolution():
+    from signal_generator import generate_timestamps
+    ts = generate_timestamps(0.0, 1.0, 2.0)
+    assert len(ts) == 2
+    assert abs(ts[0] - 0.5) < 1e-10
+    assert abs(ts[1] - 1.0) < 1e-10
+
+
+def test_generate_timestamps_no_points():
+    from signal_generator import generate_timestamps
+    ts = generate_timestamps(0.0, 0.1, 1.0)
+    assert ts == []
+
+
+def test_generate_timestamps_excludes_start():
+    from signal_generator import generate_timestamps
+    ts = generate_timestamps(10.0, 12.0, 1.0)
+    assert ts[0] == 11.0
+    assert ts[-1] == 12.0
+
+
+def test_generate_signal_basic():
+    from signal_generator import generate_signal, make_constant
+    fn = make_constant(42.0)
+    timestamps = [1.0, 2.0, 3.0]
+    points = generate_signal(fn, timestamps)
+    assert points == [(1.0, 42.0), (2.0, 42.0), (3.0, 42.0)]
+
+
+def test_generate_signal_empty():
+    from signal_generator import generate_signal, make_constant
+    fn = make_constant(1.0)
+    points = generate_signal(fn, [])
+    assert points == []
+
+
+# ---------------------------------------------------------------------------
+# Writing and cache tests
+# ---------------------------------------------------------------------------
+
+def test_write_points_default_db(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import write_points
+    mock = MockInfluxDB3Local()
+    points = [(1000000000.0, 42.5), (2000000000.0, 43.1)]
+    written = write_points(mock, points, "signal", "value", {}, None)
+    assert written == 2
+    # Single batch write
+    assert len(mock.written_lines) == 1
+    batch = mock.written_lines[0]
+    # Batch should produce a newline-separated string with 2 lines
+    built = batch.build()
+    assert len(built.split("\n")) == 2
+    assert len(mock.written_to_db) == 0
+
+
+def test_write_points_target_db(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import write_points
+    mock = MockInfluxDB3Local()
+    points = [(1000000000.0, 42.5)]
+    written = write_points(mock, points, "signal", "value", {}, "other_db")
+    assert written == 1
+    assert len(mock.written_lines) == 0
+    assert len(mock.written_to_db) == 1
+    assert mock.written_to_db[0][0] == "other_db"
+
+
+def test_write_points_with_tags(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import write_points, _BatchLines
+    mock = MockInfluxDB3Local()
+    points = [(1000000000.0, 42.5)]
+    written = write_points(mock, points, "signal", "value", {"host": "srv1"}, None)
+    assert written == 1
+    batch = mock.written_lines[0]
+    built = batch.build()
+    assert "host=srv1" in built
+
+
+def test_write_points_empty(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import write_points
+    mock = MockInfluxDB3Local()
+    written = write_points(mock, [], "signal", "value", {}, None)
+    assert written == 0
+    assert len(mock.written_lines) == 0
+
+
+def test_get_last_time_empty_cache():
+    from signal_generator import get_last_time
+    cache = MockCache()
+    assert get_last_time(cache) is None
+
+
+def test_get_set_last_time():
+    from signal_generator import get_last_time, set_last_time
+    cache = MockCache()
+    set_last_time(cache, 12345.678)
+    assert get_last_time(cache) == 12345.678
+
+
+# ---------------------------------------------------------------------------
+# Entry point tests
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, timezone
+
+
+def count_written_points(mock):
+    """Count total data points across all batch writes (default db + target db)."""
+    total = 0
+    for batch in mock.written_lines:
+        total += len(batch.build().split("\n"))
+    for _, batch in mock.written_to_db:
+        total += len(batch.build().split("\n"))
+    return total
+
+
+def test_process_scheduled_call_first_run(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    call_time = datetime(2026, 4, 10, 12, 0, 0)
+    process_scheduled_call(mock, call_time)
+    # First run: no writes, only cache initialization
+    assert len(mock.written_lines) == 0
+    assert mock.cache.get("signal_gen:last_time") is not None
+
+
+def test_process_scheduled_call_second_run(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    # Simulate first run
+    first_time = datetime(2026, 4, 10, 12, 0, 0)
+    process_scheduled_call(mock, first_time)
+    # Second run 5 seconds later — should produce 5 points at 1 pps
+    second_time = datetime(2026, 4, 10, 12, 0, 5)
+    process_scheduled_call(mock, second_time)
+    assert count_written_points(mock) == 5
+
+
+def test_process_scheduled_call_custom_pps(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    args = {"points_per_second": "2"}
+    first_time = datetime(2026, 4, 10, 12, 0, 0)
+    process_scheduled_call(mock, first_time, args)
+    # Second run 5 seconds later — 2 pps * 5s = 10 points
+    second_time = datetime(2026, 4, 10, 12, 0, 5)
+    process_scheduled_call(mock, second_time, args)
+    assert count_written_points(mock) == 10
+
+
+def test_process_scheduled_call_target_database(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    args = {"target_database": "other_db"}
+    first_time = datetime(2026, 4, 10, 12, 0, 0)
+    process_scheduled_call(mock, first_time, args)
+    second_time = datetime(2026, 4, 10, 12, 0, 5)
+    process_scheduled_call(mock, second_time, args)
+    # All writes should go to target db
+    assert len(mock.written_lines) == 0
+    assert count_written_points(mock) == 5
+    assert all(db == "other_db" for db, _ in mock.written_to_db)
+
+
+def test_process_scheduled_call_bad_waveform_config(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    args = {"waveforms": "not valid json"}
+    call_time = datetime(2026, 4, 10, 12, 0, 0)
+    process_scheduled_call(mock, call_time, args)
+    # Should log error and not crash
+    assert len(mock.written_lines) == 0
+    assert any("error" in log.lower() or "invalid" in log.lower() or "failed" in log.lower()
+               for log in mock.logs["error"])
+
+
+def test_process_scheduled_call_updates_cache(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    first_time = datetime(2026, 4, 10, 12, 0, 0)
+    process_scheduled_call(mock, first_time)
+    cached_after_first = mock.cache.get("signal_gen:last_time")
+    second_time = datetime(2026, 4, 10, 12, 0, 10)
+    process_scheduled_call(mock, second_time)
+    cached_after_second = mock.cache.get("signal_gen:last_time")
+    # Cache should be updated to second call time
+    assert cached_after_second > cached_after_first


### PR DESCRIPTION
## Summary
- move Signal Generator plugin into influxdata/signal_generator
- register Signal Generator in plugin_library.json with beta InfluxDB 3.8.2+ requirement text
- add prominent README note for the known CLI --trigger-arguments JSON comma parsing issue and use API examples for configured triggers

## Tests
- python3 -m json.tool influxdata/library/plugin_library.json /tmp/plugin_library.json
- env PYTHONPYCACHEPREFIX=/tmp/influxdb3_plugins_pycache python3 -m py_compile influxdata/signal_generator/signal_generator.py influxdata/signal_generator/test_signal_generator.py
- PYTHONPATH=influxdata/signal_generator python3 -m pytest influxdata/signal_generator/test_signal_generator.py (not run: pytest missing in local Python)
- custom in-process runner: 75 tests passed
- python3 scripts/validate_readme.py --plugins signal_generator --quiet
- python3 scripts/validate_influxdb3_syntax.py --readme /Users/rcater/Repos/LibrarySrc/influxdb3_plugins/influxdata/signal_generator/README.md --cli-only --errors-only