### PR TITLE
Add stock portfolio tracker plugin

### DIFF
--- a/influxdata/library/plugin_library.json
+++ b/influxdata/library/plugin_library.json
@@ -317,6 +317,17 @@
                 "required_libraries": [],
                 "last_update": "2026-06-10",
                 "trigger_types_supported": ["scheduler", "data_writes"]
+            },
+            {
+                "name": "Stock Portfolio Tracker",
+                "path": "influxdata/stock_plugin/stock_plugin.py",
+                "description": "[BETA] Tracks stock, ETF, and mutual fund portfolio values from Yahoo Finance with market-hours gating and rollups.",
+                "author": "InfluxData",
+                "docs_file_link": "https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/stock_plugin/README.md",
+                "required_plugins": [],
+                "required_libraries": ["yfinance", "pandas_market_calendars"],
+                "last_update": "2026-06-10",
+                "trigger_types_supported": ["scheduler"]
             }
         ]
     }

--- a/influxdata/stock_plugin/README.md
+++ b/influxdata/stock_plugin/README.md
@@ -1,0 +1,255 @@
+# Stock Portfolio Tracker Plugin
+
+⚡ scheduled 🏷️ portfolio, stocks, finance, yfinance, market-data 🔧 InfluxDB 3 Core, InfluxDB 3 Enterprise
+
+## Description
+
+The Stock Portfolio Tracker plugin periodically fetches current stock, ETF, and mutual fund prices from Yahoo Finance and writes per-holding rows plus per-portfolio and per-category roll-up totals to InfluxDB 3. Configure your holdings inline as trigger arguments or in a TOML file, group them into named portfolios (e.g. `401k`, `brokerage`) and user-defined categories (e.g. `Retirement`, `Investment`), and the plugin will track the value of each holding and each grouping over time. Built-in gating skips fetches during market closures (with a clear log line so dashboard gaps have a known cause), polls mutual funds only once per day after NAV close, and carries forward the last known price for skipped symbols so portfolio totals stay accurate.
+
+### Scope
+
+Yahoo Finance supports tickers from many global exchanges (e.g. `.L` for London, `.T` for Tokyo, `.PA` for Paris), so the price-fetch path works for international holdings out of the box. The **market-hours gating** is also internationalizable: `market_calendar` and `market_timezone` configure which exchange's calendar to use. Defaults are US-centric (`NYSE` / `America/New_York`) because that's the most common case, but any exchange name accepted by [pandas_market_calendars](https://pandas-market-calendars.readthedocs.io/) works (LSE, TSX, JPX, XETR, ASX, HKEX, etc.). Currency conversion is **not** performed — all values are stored in whatever currency yfinance returns per symbol; this is recorded on the `currency` field of `stock_holdings` rows. If your portfolio mixes currencies, do conversion at query time.
+
+## Configuration
+
+Plugin parameters may be specified as key-value pairs in the `--trigger-arguments` flag (CLI) or in the `trigger_arguments` field (API) when creating a trigger. The plugin also supports a TOML configuration file for the full portfolio shape; the trigger-argument form is best for one-off testing.
+
+### Plugin metadata
+
+This plugin includes a JSON metadata schema in its docstring that defines the supported trigger type and configuration parameters. This metadata enables the InfluxDB 3 Explorer UI to display and configure the plugin.
+
+### Optional parameters
+
+| Parameter     | Type   | Default                | Description                                                                                                                                              |
+|---------------|--------|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `database`    | string | `stocks`               | Target database for writes. Overrides the TOML `database` key if both are set.                                                                           |
+| `portfolio`   | string | none                   | Inline holdings: pipe-separated `SYMBOL:QUANTITY[:PORTFOLIO_NAME]` entries (e.g. `AAPL:10:401k\|MSFT:5:401k\|GOOG:2.5:brokerage`). Portfolio defaults to `main`. |
+| `categories`  | string | none                   | Inline category map: pipe-separated `PORTFOLIO:CATEGORY` entries (e.g. `401k:Retirement\|brokerage:Investment`).                                          |
+| `config_path` | string | `stock_plugin.toml`    | Path to the TOML config file, relative to the InfluxDB plugin directory (or absolute).                                                                   |
+
+*One of `portfolio` or a TOML file containing at least one `[holdings.<name>]` table is required.*
+
+### TOML configuration
+
+The TOML file is the recommended way to configure anything more than a handful of holdings. The plugin reads it from `config_path` (default: `<plugin-dir>/stock_plugin.toml`).
+
+| Key                         | Type    | Default     | Description                                                                                                                                                          |
+|-----------------------------|---------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `database`                  | string  | `stocks`            | Target database for writes.                                                                                                                                          |
+| `stock_interval_minutes`    | integer | ignored             | Legacy compatibility key. Ignored if present; the Processing Engine trigger spec controls how often the plugin runs and fetches.                                      |
+| `write_during_closed_hours` | boolean | `true`              | When `false`, stocks/ETFs are skipped outside the configured exchange's regular session (the calendar handles holidays and early closes). Mutual funds always follow their own daily check schedule. |
+| `mutual_fund_check_time`    | string  | `"18:00"`           | Time of day in `market_timezone` after which the plugin fetches mutual fund NAV. Mutual funds are fetched at most once per local calendar day, at the first tick at or after this time. Bootstrap exception: a mutual fund with no cached asset type is fetched on its first tick regardless of time. |
+| `market_calendar`           | string  | `"NYSE"`            | Exchange calendar used for the market-hours check. Any name accepted by [pandas_market_calendars](https://pandas-market-calendars.readthedocs.io/) (e.g. `NYSE`, `LSE`, `TSX`, `JPX`, `XETR`, `ASX`, `HKEX`). |
+| `market_timezone`           | string  | `"America/New_York"`| IANA timezone for the exchange's local time. Used for `mutual_fund_check_time` comparisons and for resolving the "today" date the calendar consults.                |
+| `[portfolio_categories]`    | table   | empty               | Maps portfolio name to category name. Portfolios not listed are uncategorized (omitted from `category_totals`).                                                      |
+| `[holdings.<portfolio>]`    | table   | required            | Holdings for each portfolio. Each entry is `SYMBOL = quantity`. Fractional quantities supported. Quote symbols containing dots, for example `"VOD.L" = 10`. Duplicate same-symbol entries in one portfolio are aggregated. The portfolio name `_total` is reserved. |
+
+The trigger spec is the source of truth for cadence. For example, `--trigger-spec "every:15m"` runs the plugin every 15 minutes. `stock_interval_minutes`, if present in TOML, is ignored and does not throttle plugin execution.
+
+#### Example TOML configuration
+
+[stock_plugin.toml.example](stock_plugin.toml.example)
+
+## Software requirements
+
+- **InfluxDB 3 Core/Enterprise**: with the Processing Engine enabled.
+- **Python packages** (installed into the plugin venv):
+  - `yfinance` — Yahoo Finance scraper for price data
+  - `pandas_market_calendars` — NYSE calendar for accurate market-hours and holiday gating
+
+### Installation steps
+
+1. Start InfluxDB 3 with the Processing Engine enabled (`--plugin-dir /path/to/plugins`):
+
+   ```bash
+   influxdb3 serve \
+     --node-id node0 \
+     --object-store file \
+     --data-dir ~/.influxdb3 \
+     --plugin-dir ~/.plugins
+   ```
+
+2. Install required Python packages:
+
+   ```bash
+   influxdb3 install package yfinance pandas_market_calendars
+   ```
+
+3. Copy `stock_plugin.toml.example` to `<plugin-dir>/stock_plugin.toml` and edit it with your holdings and categories.
+
+## Trigger setup
+
+### Basic scheduled trigger (TOML config)
+
+```bash
+influxdb3 create trigger \
+  --database stocks \
+  --path "stock_plugin.py" \
+  --trigger-spec "every:15m" \
+  --trigger-arguments config_path=stock_plugin.toml \
+  --error-behavior log \
+  stock_portfolio_tracker
+```
+
+### Inline holdings without TOML
+
+```bash
+influxdb3 create trigger \
+  --database stocks \
+  --path "stock_plugin.py" \
+  --trigger-spec "every:15m" \
+  --trigger-arguments 'portfolio=AAPL:10:401k|MSFT:5:401k|GOOG:2:brokerage,categories=401k:Retirement|brokerage:Investment' \
+  --error-behavior log \
+  stock_portfolio_tracker
+```
+
+### Skip writes when the configured market is closed
+
+Set `write_during_closed_hours = false` in your TOML config and create the trigger as normal. With the default NYSE calendar, stocks and ETFs will skip outside 9:30–16:00 ET on weekdays and on NYSE holidays. Their portfolio total values are still maintained via carry-forward.
+
+On a cold cache, such as after an InfluxDB restart, a symbol that would otherwise be skipped can be fetched once so the plugin has a last-known price to carry forward on later skipped ticks. The summary log calls these out as cold-cache bootstrap fetches.
+
+## Example usage
+
+### Latest portfolio value by category
+
+```bash
+influxdb3 query \
+  --database stocks \
+  "SELECT category, value, portfolio_count, symbol_count
+   FROM category_totals
+   WHERE time = (SELECT MAX(time) FROM category_totals)"
+```
+
+**Expected output**
+
+```
++------------+-----------+-----------------+--------------+
+| category   | value     | portfolio_count | symbol_count |
++------------+-----------+-----------------+--------------+
+| Investment | 257908.71 | 2               | 17           |
+| Retirement | 1990604.5 | 3               | 5            |
++------------+-----------+-----------------+--------------+
+```
+
+### Total portfolio value over time
+
+```bash
+influxdb3 query \
+  --database stocks \
+  "SELECT time, value FROM portfolio_totals
+   WHERE portfolio = '_total' ORDER BY time DESC LIMIT 10"
+```
+
+### Daily P&L per holding (using previous_close)
+
+```bash
+influxdb3 query \
+  --database stocks \
+  "SELECT symbol, portfolio,
+          (price - previous_close) * quantity AS daily_change
+   FROM stock_holdings
+   WHERE time = (SELECT MAX(time) FROM stock_holdings)
+     AND previous_close IS NOT NULL
+   ORDER BY daily_change DESC"
+```
+
+### Filter for fully fresh rows
+
+Rows in `portfolio_totals` and `category_totals` carry `missing_symbols`, `skipped_symbols`, and `carried_symbols` counts so dashboards can distinguish fully fresh data from carry-forward or partial fetches:
+
+```sql
+-- "All symbols fetched fresh this tick"
+SELECT * FROM portfolio_totals
+WHERE missing_symbols = 0 AND skipped_symbols = 0;
+
+-- "All values present (fresh + carry-forward), no failures"
+SELECT * FROM portfolio_totals
+WHERE missing_symbols = 0;
+```
+
+## Code overview
+
+### Main functions
+
+#### `process_scheduled_call(influxdb3_local, call_time, args)`
+
+Entry point for the scheduled trigger. Resolves the plugin directory from `INFLUXDB3_PLUGIN_DIR`, normalizes `call_time` to UTC, and delegates to `_main` with the runtime-injected `LineBuilder` and the live `influxdb3_local`. All side-effecting work lives in `_main` so its logic can be reasoned about with injected dependencies.
+
+#### `_main(local, args, fetcher, line_builder_cls, plugin_dir, now_ns)`
+
+Drives the full plugin flow:
+
+1. Resolve config from trigger args + TOML.
+2. Determine configured market state via `pandas_market_calendars` and parse the mutual-fund check time.
+3. For each configured holding, decide whether to fetch (gated by asset type, cached state, and config), fetch via `yfinance.fast_info`, and build a `HoldingRow`.
+4. Build carry-forward `HoldingRow`s for intentionally-skipped symbols whose last known price is cached.
+5. Aggregate per-portfolio totals + a grand `_total` row.
+6. Aggregate per-category totals across portfolios.
+7. Emit line protocol via `LineBuilder` for `stock_holdings`, `portfolio_totals`, and `category_totals`.
+8. Log a single summary line.
+
+### Measurements and fields
+
+#### `stock_holdings`
+
+One row per symbol per successful fetch. Carry-forward symbols are NOT written here (their last fresh row remains the most recent record in this measurement).
+
+- **Tags**: `symbol`, `portfolio`, `asset_type` (`equity`, `etf`, `mutualfund`, `other`), `category` (omitted if portfolio is uncategorized)
+- **Fields**: `price`, `quantity`, `value`, `currency`, `previous_close`, `day_open`, `day_high`, `day_low`
+
+#### `portfolio_totals`
+
+One row per configured portfolio plus a `_total` grand-total row, written every tick.
+
+- **Tags**: `portfolio`, `category` (omitted if uncategorized; always omitted on `_total`)
+- **Fields**: `value`, `symbol_count`, `missing_symbols`, `skipped_symbols`, `carried_symbols`
+
+#### `category_totals`
+
+One row per defined category, rolled up across portfolios in that category. Uncategorized portfolios and the `_total` row are excluded to avoid double-counting.
+
+- **Tags**: `category`
+- **Fields**: `value`, `symbol_count`, `portfolio_count`, `missing_symbols`, `skipped_symbols`, `carried_symbols`
+
+### Internal cache keys
+
+The plugin uses `influxdb3_local.cache` (no TTL) for state across runs:
+
+| Key                          | Value           | Purpose                                                                                                       |
+|------------------------------|-----------------|---------------------------------------------------------------------------------------------------------------|
+| `asset_type:<SYMBOL>`        | string          | Cached `yfinance.fast_info.quote_type` so we don't re-derive it each run.                                     |
+| `last_mf_date:<SYMBOL>`      | `YYYY-MM-DD` (ET) | Last calendar day a mutual fund was fetched. Used to enforce once-per-day NAV polling.                        |
+| `last_price:<SYMBOL>`        | float           | Last known price. Used to carry forward portfolio value when a symbol is skipped.                             |
+
+Cache is cleared on server restart. The plugin self-bootstraps: any symbol with a missing cache key gets a fresh fetch on its next tick regardless of skip rules.
+
+## Troubleshooting
+
+### Common issues
+
+#### Issue: No holdings are configured
+
+**Solution:** Provide either `portfolio` trigger arguments or a TOML file with at least one `[holdings.<portfolio>]` table.
+
+The plugin requires at least one holding before it can write portfolio rows. If you use a TOML file, confirm that `config_path` points to the file in the InfluxDB 3 plugin directory.
+
+#### Issue: Market-hours checks skip expected writes
+
+**Solution:** Set `write_during_closed_hours = true` or choose the correct `market_calendar` and `market_timezone` for your exchange.
+
+When `write_during_closed_hours` is false, the plugin uses `pandas_market_calendars` to skip equity and ETF fetches outside the configured exchange session. Mutual funds are still gated by `mutual_fund_check_time`.
+
+#### Issue: Yahoo Finance returns missing prices
+
+**Solution:** Verify the ticker symbol and check whether Yahoo Finance exposes current price data for that instrument.
+
+The plugin carries forward the last known price for intentionally skipped symbols, but it cannot value a new holding until the first successful fetch.
+
+### Debugging tips
+
+Check `system.processing_engine_logs` for the trigger summary line. It reports fetched, skipped, carried, and missing symbol counts for each scheduled run.
+
+## Questions/Comments
+
+For additional support, see the [Support section](../README.md#support).

--- a/influxdata/stock_plugin/README.md
+++ b/influxdata/stock_plugin/README.md
@@ -36,7 +36,6 @@ The TOML file is the recommended way to configure anything more than a handful o
 | Key                         | Type    | Default     | Description                                                                                                                                                          |
 |-----------------------------|---------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `database`                  | string  | `stocks`            | Target database for writes.                                                                                                                                          |
-| `stock_interval_minutes`    | integer | ignored             | Legacy compatibility key. Ignored if present; the Processing Engine trigger spec controls how often the plugin runs and fetches.                                      |
 | `write_during_closed_hours` | boolean | `true`              | When `false`, stocks/ETFs are skipped outside the configured exchange's regular session (the calendar handles holidays and early closes). Mutual funds always follow their own daily check schedule. |
 | `mutual_fund_check_time`    | string  | `"18:00"`           | Time of day in `market_timezone` after which the plugin fetches mutual fund NAV. Mutual funds are fetched at most once per local calendar day, at the first tick at or after this time. Bootstrap exception: a mutual fund with no cached asset type is fetched on its first tick regardless of time. |
 | `market_calendar`           | string  | `"NYSE"`            | Exchange calendar used for the market-hours check. Any name accepted by [pandas_market_calendars](https://pandas-market-calendars.readthedocs.io/) (e.g. `NYSE`, `LSE`, `TSX`, `JPX`, `XETR`, `ASX`, `HKEX`). |
@@ -44,7 +43,7 @@ The TOML file is the recommended way to configure anything more than a handful o
 | `[portfolio_categories]`    | table   | empty               | Maps portfolio name to category name. Portfolios not listed are uncategorized (omitted from `category_totals`).                                                      |
 | `[holdings.<portfolio>]`    | table   | required            | Holdings for each portfolio. Each entry is `SYMBOL = quantity`. Fractional quantities supported. Quote symbols containing dots, for example `"VOD.L" = 10`. Duplicate same-symbol entries in one portfolio are aggregated. The portfolio name `_total` is reserved. |
 
-The trigger spec is the source of truth for cadence. For example, `--trigger-spec "every:15m"` runs the plugin every 15 minutes. `stock_interval_minutes`, if present in TOML, is ignored and does not throttle plugin execution.
+The trigger spec is the source of truth for cadence. For example, `--trigger-spec "every:15m"` runs the plugin every 15 minutes.
 
 #### Example TOML configuration
 

--- a/influxdata/stock_plugin/manifest.toml
+++ b/influxdata/stock_plugin/manifest.toml
@@ -1,0 +1,19 @@
+manifest_schema_version = "1.2"
+
+[plugin]
+name = "stock_plugin"
+version = "0.1.0"
+description = "Tracks stock, ETF, and mutual fund portfolio values from Yahoo Finance with market-hours gating and rollups."
+triggers = ["process_scheduled_call"]
+homepage = "https://www.influxdata.com/"
+repository = "https://github.com/influxdata/influxdb3_plugins/tree/main/influxdata/stock_plugin"
+documentation = "https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/stock_plugin/README.md"
+exclude = [
+  ".git/", ".venv/", "__pycache__/", "*.pyc", "tests/**",
+  ".claude/", ".vscode/", ".idea/", ".DS_Store",
+  "*.py", "!stock_plugin.py",
+]
+
+[dependencies]
+database_version = ">=3.0.0"
+python = ["yfinance>=0.2.40", "pandas_market_calendars>=4.4"]

--- a/influxdata/stock_plugin/requirements.txt
+++ b/influxdata/stock_plugin/requirements.txt
@@ -1,0 +1,2 @@
+yfinance>=0.2.40
+pandas_market_calendars>=4.4

--- a/influxdata/stock_plugin/stock_plugin.py
+++ b/influxdata/stock_plugin/stock_plugin.py
@@ -1,0 +1,965 @@
+"""InfluxDB 3 Processing Engine plugin: stock portfolio tracker.
+
+Scheduled plugin that fetches stock prices from Yahoo Finance (via
+yfinance) and writes per-symbol holdings plus per-portfolio totals to
+InfluxDB. Trigger cadence is controlled by the Processing Engine trigger
+spec, typically `every:15m`.
+
+Per-symbol fetch gating:
+  * stocks/etfs: fetched every tick UNLESS write_during_closed_hours is
+    false AND the configured market (default NYSE) regular session is
+    currently closed. Market hours come from pandas_market_calendars
+    (handles holidays and early closes). Set market_calendar and
+    market_timezone in TOML to gate against a non-US exchange (LSE,
+    JPX, TSX, XETR, etc.).
+  * mutual funds: fetched at most once per local calendar day, at the
+    first tick at or after mutual_fund_check_time. Bootstrap exception:
+    a mutual fund with no cached asset_type is fetched on its first tick
+    regardless of time so the plugin can learn its type and record an
+    initial row.
+  * cold-cache bootstrap: if a symbol would be skipped but has no cached
+    last price, it is fetched once so carry-forward totals can work on
+    later skipped ticks.
+
+Per-symbol asset_type is detected from yfinance.fast_info.quote_type on
+first fetch and cached (no TTL) in influxdb3_local.cache.
+
+The InfluxDB runtime injects `influxdb3_local` and `LineBuilder` as
+globals. These are referenced ONLY inside process_scheduled_call (and
+_main, which takes them as parameters). The module imports cleanly in
+plain Python; yfinance and pandas_market_calendars are imported lazily
+inside the functions that use them.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+
+def _parse_hhmm(s: str) -> tuple[int, int]:
+    """Parse a HH:MM time string. Raises ValueError on bad input."""
+    parts = s.strip().split(":")
+    if len(parts) != 2:
+        raise ValueError(f"invalid HH:MM time {s!r}: expected HH:MM")
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError as e:
+        raise ValueError(f"invalid HH:MM time {s!r}: non-numeric") from e
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"invalid HH:MM time {s!r}: out of range")
+    return hour, minute
+
+
+def _normalize_quote_type(qt: Optional[str]) -> str:
+    """Map yfinance fast_info.quote_type to our normalized asset_type tag."""
+    if not qt:
+        return "other"
+    qt = qt.upper()
+    if qt == "EQUITY":
+        return "equity"
+    if qt == "ETF":
+        return "etf"
+    if qt == "MUTUALFUND":
+        return "mutualfund"
+    return "other"
+
+
+def _is_market_open(
+    now_utc: datetime, calendar_name: str, tz: ZoneInfo
+) -> bool:
+    """Return True if the given exchange's regular session is currently open.
+
+    `calendar_name` is any name accepted by pandas_market_calendars
+    (e.g. "NYSE", "LSE", "TSX", "JPX", "XETR"). `tz` is the local
+    timezone of the exchange — used to determine "today" relative to
+    the local market day, not UTC.
+
+    Imported lazily so the module remains AST-parseable without the
+    dependency.
+    """
+    import pandas_market_calendars as mcal
+    cal = mcal.get_calendar(calendar_name)
+    today_local = now_utc.astimezone(tz).date()
+    schedule = cal.schedule(start_date=today_local, end_date=today_local)
+    if schedule.empty:
+        return False
+    market_open = schedule.iloc[0]["market_open"].to_pydatetime()
+    market_close = schedule.iloc[0]["market_close"].to_pydatetime()
+    return market_open <= now_utc <= market_close
+
+
+@dataclass
+class Holding:
+    """A configured holding: symbol + quantity + portfolio name."""
+    symbol: str
+    quantity: float
+    portfolio: str
+
+
+@dataclass
+class Quote:
+    """A successful price fetch result for a single symbol."""
+    symbol: str
+    price: float
+    currency: str
+    asset_type: str
+    previous_close: Optional[float]
+    day_open: Optional[float]
+    day_high: Optional[float]
+    day_low: Optional[float]
+
+
+@dataclass
+class HoldingRow:
+    """A row of the stock_holdings measurement, ready to write."""
+    symbol: str
+    portfolio: str
+    asset_type: str
+    category: str  # empty string = no category configured
+    price: float
+    quantity: float
+    value: float
+    currency: str
+    previous_close: Optional[float]
+    day_open: Optional[float]
+    day_high: Optional[float]
+    day_low: Optional[float]
+    timestamp_ns: int
+
+
+@dataclass
+class TotalRow:
+    """A row of the portfolio_totals measurement.
+
+    value = sum of (fresh fetches + carry-forward from last known price)
+    symbol_count = configured holdings
+    missing_symbols = fetch failures (no value available)
+    skipped_symbols = intentionally not fetched (mutual-fund off-time or
+                      market closed); includes carried symbols
+    carried_symbols = subset of skipped that contributed a cached
+                      last-known price to `value`
+    category = user-defined portfolio category (empty for `_total`)
+    """
+    portfolio: str
+    category: str  # empty string = no category configured
+    value: float
+    symbol_count: int
+    missing_symbols: int
+    skipped_symbols: int
+    carried_symbols: int
+    timestamp_ns: int
+
+
+@dataclass
+class CategoryRow:
+    """A row of the category_totals measurement (rolled up across portfolios)."""
+    category: str
+    value: float
+    symbol_count: int
+    portfolio_count: int
+    missing_symbols: int
+    skipped_symbols: int
+    carried_symbols: int
+    timestamp_ns: int
+
+
+@dataclass
+class ResolvedConfig:
+    """Final, validated configuration after merging trigger args and TOML."""
+    database: str
+    holdings_by_portfolio: dict[str, list[Holding]]
+    categories: dict[str, str]  # portfolio name -> category name
+    write_during_closed_hours: bool = True
+    mutual_fund_check_time: str = "18:00"
+    market_calendar: str = "NYSE"
+    market_timezone: str = "America/New_York"
+
+
+def parse_inline_portfolio(value: str) -> dict[str, list[Holding]]:
+    """Parse the inline `portfolio=` trigger argument.
+
+    Format: pipe-separated holdings. Each holding is `SYMBOL:QUANTITY` or
+    `SYMBOL:QUANTITY:PORTFOLIO_NAME`. Defaults to portfolio "main" if the
+    portfolio name is omitted.
+
+    Examples:
+        "AAPL:10"                            -> {"main": [Holding(AAPL, 10, main)]}
+        "AAPL:10|MSFT:5"                     -> two holdings, both in "main"
+        "AAPL:10:401k|GOOG:2.5:brokerage"    -> across two portfolios
+
+    Raises ValueError on any malformed input.
+    """
+    if not value or not value.strip():
+        raise ValueError("portfolio argument is empty")
+    result: dict[str, list[Holding]] = {}
+    for raw in value.split("|"):
+        raw = raw.strip()
+        if not raw:
+            raise ValueError(
+                f"invalid portfolio argument {value!r}: empty token "
+                f"(check for leading, trailing, or doubled '|')"
+            )
+        parts = raw.split(":")
+        if len(parts) not in (2, 3):
+            raise ValueError(
+                f"invalid holding spec {raw!r}: expected SYMBOL:QUANTITY[:PORTFOLIO]"
+            )
+        symbol = parts[0].strip().upper()
+        if not symbol:
+            raise ValueError(f"invalid holding spec {raw!r}: empty symbol")
+        try:
+            quantity = float(parts[1])
+        except ValueError as e:
+            raise ValueError(
+                f"invalid quantity {parts[1]!r} in {raw!r}"
+            ) from e
+        if len(parts) == 3 and parts[2].strip():
+            portfolio = parts[2].strip()
+        else:
+            portfolio = "main"
+        result.setdefault(portfolio, []).append(
+            Holding(symbol=symbol, quantity=quantity, portfolio=portfolio)
+        )
+    return result
+
+
+def parse_inline_categories(value: str) -> dict[str, str]:
+    """Parse the inline `categories=` trigger argument.
+
+    Format: pipe-separated entries, each `PORTFOLIO_NAME:CATEGORY_NAME`.
+    Example: "401k:Retirement|brokerage:Investment"
+
+    Raises ValueError on any malformed input.
+    """
+    if not value or not value.strip():
+        raise ValueError("categories argument is empty")
+    result: dict[str, str] = {}
+    for raw in value.split("|"):
+        raw = raw.strip()
+        if not raw:
+            raise ValueError(
+                f"invalid categories argument {value!r}: empty token "
+                f"(check for leading, trailing, or doubled '|')"
+            )
+        parts = raw.split(":")
+        if len(parts) != 2:
+            raise ValueError(
+                f"invalid category spec {raw!r}: expected PORTFOLIO:CATEGORY"
+            )
+        portfolio_name = parts[0].strip()
+        category_name = parts[1].strip()
+        if not portfolio_name or not category_name:
+            raise ValueError(
+                f"invalid category spec {raw!r}: empty portfolio or category name"
+            )
+        result[portfolio_name] = category_name
+    return result
+
+
+def _aggregate_duplicate_holdings(
+    holdings_by_portfolio: dict[str, list[Holding]]
+) -> dict[str, list[Holding]]:
+    """Combine duplicate symbols within each portfolio into one holding."""
+    result: dict[str, list[Holding]] = {}
+    for portfolio, holdings in holdings_by_portfolio.items():
+        order: list[str] = []
+        by_symbol: dict[str, Holding] = {}
+        for holding in holdings:
+            existing = by_symbol.get(holding.symbol)
+            if existing is None:
+                order.append(holding.symbol)
+                by_symbol[holding.symbol] = Holding(
+                    symbol=holding.symbol,
+                    quantity=holding.quantity,
+                    portfolio=holding.portfolio,
+                )
+            else:
+                by_symbol[holding.symbol] = Holding(
+                    symbol=holding.symbol,
+                    quantity=existing.quantity + holding.quantity,
+                    portfolio=holding.portfolio,
+                )
+        result[portfolio] = [by_symbol[symbol] for symbol in order]
+    return result
+
+
+def _validate_market_calendar(calendar_name: str) -> None:
+    """Fail fast if pandas_market_calendars does not know this calendar."""
+    try:
+        import pandas_market_calendars as mcal
+    except ImportError as e:
+        raise ValueError(
+            "pandas_market_calendars is required to validate market_calendar; "
+            "install it in the plugin environment"
+        ) from e
+
+    try:
+        mcal.get_calendar(calendar_name)
+    except Exception as e:
+        raise ValueError(
+            f"market_calendar {calendar_name!r} is not accepted by "
+            f"pandas_market_calendars: {e}"
+        ) from e
+
+
+def load_toml_config(path: Path) -> tuple[dict, dict[str, list[Holding]]]:
+    """Load TOML config from `path`.
+
+    Returns (top_level_data_dict, holdings_by_portfolio). The full raw
+    TOML top-level dict is returned so resolve_config can pick out
+    optional scalar keys (database, market_calendar, etc).
+
+    Expected TOML shape:
+        database = "stocks"
+        write_during_closed_hours = true
+        mutual_fund_check_time = "18:00"
+
+        [holdings.401k]
+        AAPL = 10
+        MSFT = 5
+
+        [holdings.brokerage]
+        GOOG = 2.5
+
+    Raises:
+        FileNotFoundError: path does not exist
+        tomllib.TOMLDecodeError: file is not valid TOML
+        ValueError: no usable [holdings.<portfolio>] sections
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"TOML config not found: {path}")
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    holdings_section = data.get("holdings", {})
+    if not isinstance(holdings_section, dict) or not holdings_section:
+        raise ValueError(
+            f"TOML config at {path} has no [holdings.<portfolio>] sections"
+        )
+    result: dict[str, list[Holding]] = {}
+    for portfolio_name, mapping in holdings_section.items():
+        if not isinstance(mapping, dict):
+            continue
+        for symbol, quantity in mapping.items():
+            if isinstance(quantity, dict):
+                dotted_hint = symbol
+                if quantity:
+                    dotted_hint = f"{symbol}.{next(iter(quantity))}"
+                raise ValueError(
+                    f"invalid quantity {quantity!r} for symbol {symbol!r} "
+                    f"in [holdings.{portfolio_name}]. If this is a dotted "
+                    f"ticker symbol, quote it in TOML, for example "
+                    f'"{dotted_hint}" = 1'
+                )
+            try:
+                qty = float(quantity)
+            except (TypeError, ValueError) as e:
+                raise ValueError(
+                    f"invalid quantity {quantity!r} for symbol {symbol!r} "
+                    f"in [holdings.{portfolio_name}]"
+                ) from e
+            result.setdefault(portfolio_name, []).append(
+                Holding(
+                    symbol=symbol.upper(),
+                    quantity=qty,
+                    portfolio=portfolio_name,
+                )
+            )
+    if not result:
+        raise ValueError(
+            f"TOML config at {path} has empty [holdings.<portfolio>] sections"
+        )
+    return data, result
+
+
+def resolve_config_path(path: str, default_toml_path: Path) -> Path:
+    """Resolve TOML config path using the plugin-dir fallbacks used by plugins.
+
+    Absolute paths are used as-is. Relative paths are resolved from
+    INFLUXDB3_PLUGIN_DIR or PLUGIN_DIR when available, then VIRTUAL_ENV's
+    parent directory, and finally the supplied default TOML directory.
+    """
+    raw_path = Path(path)
+    if raw_path.is_absolute():
+        return raw_path
+
+    candidates: list[Path] = []
+    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+        candidates.append(Path(influxdb3_plugin_dir))
+    if plugin_dir := os.environ.get("PLUGIN_DIR"):
+        candidates.append(Path(plugin_dir))
+    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+        candidates.append(Path(virtual_env).parent)
+    candidates.append(default_toml_path.parent)
+
+    for base in candidates:
+        candidate = base / raw_path
+        if candidate.exists():
+            return candidate
+    return candidates[0] / raw_path
+
+
+def resolve_config(
+    args: dict[str, str], default_toml_path: Path
+) -> ResolvedConfig:
+    """Resolve final config from trigger args + TOML.
+
+    Precedence:
+      Holdings: inline `portfolio=` arg > TOML [holdings.*] (one or the other)
+      Database: `database=` arg > TOML `database` > default "stocks"
+      Config path: `config_path=` arg > default_toml_path. Relative paths
+      resolve from INFLUXDB3_PLUGIN_DIR, PLUGIN_DIR, VIRTUAL_ENV's parent,
+      or default_toml_path.parent.
+
+    Other TOML scalars (write_during_closed_hours, mutual_fund_check_time,
+    market_calendar, market_timezone) come only from TOML — there is no
+    inline-arg override for them. Defaults apply when the key is absent.
+    Legacy `stock_interval_minutes`, if present, is ignored; the trigger
+    spec controls cadence.
+
+    Raises ValueError if neither inline holdings nor a usable TOML file is
+    found, or if any TOML scalar has an invalid value.
+    """
+    inline_portfolio = args.get("portfolio")
+    config_path = resolve_config_path(
+        args.get("config_path") or str(default_toml_path),
+        default_toml_path,
+    )
+
+    toml_data: dict = {}
+    if inline_portfolio:
+        holdings = parse_inline_portfolio(inline_portfolio)
+    else:
+        if not config_path.exists():
+            raise ValueError(
+                f"No 'portfolio' trigger arg provided and no TOML config "
+                f"at {config_path}. Either pass --trigger-arguments "
+                f"'portfolio=...' or create the TOML file."
+            )
+        toml_data, holdings = load_toml_config(config_path)
+
+    if "_total" in holdings:
+        raise ValueError(
+            "portfolio name '_total' is reserved for the grand total row; "
+            "please use a different name"
+        )
+    holdings = _aggregate_duplicate_holdings(holdings)
+
+    if args.get("database"):
+        database = args["database"]
+    elif toml_data.get("database"):
+        database = toml_data["database"]
+    else:
+        database = "stocks"
+
+    write_closed = toml_data.get("write_during_closed_hours", True)
+    if not isinstance(write_closed, bool):
+        raise ValueError(
+            f"write_during_closed_hours must be true or false; got {write_closed!r}"
+        )
+
+    mf_check = toml_data.get("mutual_fund_check_time", "18:00")
+    if not isinstance(mf_check, str):
+        raise ValueError(
+            f"mutual_fund_check_time must be a HH:MM string; got {mf_check!r}"
+        )
+    _parse_hhmm(mf_check)  # validate format, raises ValueError on bad input
+
+    market_calendar = toml_data.get("market_calendar", "NYSE")
+    if not isinstance(market_calendar, str) or not market_calendar.strip():
+        raise ValueError(
+            f"market_calendar must be a non-empty exchange name string; got {market_calendar!r}"
+        )
+    market_calendar = market_calendar.strip()
+    _validate_market_calendar(market_calendar)
+
+    market_timezone = toml_data.get("market_timezone", "America/New_York")
+    if not isinstance(market_timezone, str) or not market_timezone.strip():
+        raise ValueError(
+            f"market_timezone must be a non-empty IANA timezone string; got {market_timezone!r}"
+        )
+    try:
+        ZoneInfo(market_timezone)
+    except Exception as e:
+        raise ValueError(
+            f"market_timezone {market_timezone!r} is not a valid IANA timezone: {e}"
+        ) from e
+
+    # Resolve categories: trigger arg > TOML > {}
+    inline_categories = args.get("categories")
+    if inline_categories:
+        categories = parse_inline_categories(inline_categories)
+    else:
+        toml_cats = toml_data.get("portfolio_categories", {})
+        if not isinstance(toml_cats, dict):
+            raise ValueError(
+                f"[portfolio_categories] must be a TOML table; got {type(toml_cats).__name__}"
+            )
+        categories = {str(k): str(v) for k, v in toml_cats.items()}
+
+    return ResolvedConfig(
+        database=database,
+        holdings_by_portfolio=holdings,
+        categories=categories,
+        write_during_closed_hours=write_closed,
+        mutual_fund_check_time=mf_check,
+        market_calendar=market_calendar,
+        market_timezone=market_timezone,
+    )
+
+
+def compute_totals(
+    holdings_by_portfolio: dict[str, list[Holding]],
+    categories: dict[str, str],
+    fresh_rows: list[HoldingRow],
+    carried_rows: list[HoldingRow],
+    skipped_by_portfolio: dict[str, int],
+    timestamp_ns: int,
+) -> list[TotalRow]:
+    """Aggregate per-portfolio totals + a grand `_total` row.
+
+    `fresh_rows` are rows from a successful fetch this tick. They are also
+    written to stock_holdings (caller's responsibility).
+    `carried_rows` are synthetic rows for skipped symbols whose last
+    known price was carried forward from cache. They contribute to
+    `value` but are NOT written to stock_holdings.
+    `skipped_by_portfolio` is the total intentional-skip count per
+    portfolio (includes carried).
+    `categories` maps portfolio name -> category string (empty if not set).
+    """
+    fresh_by_portfolio: dict[str, list[HoldingRow]] = {}
+    for r in fresh_rows:
+        fresh_by_portfolio.setdefault(r.portfolio, []).append(r)
+    carried_by_portfolio: dict[str, list[HoldingRow]] = {}
+    for r in carried_rows:
+        carried_by_portfolio.setdefault(r.portfolio, []).append(r)
+
+    totals: list[TotalRow] = []
+    grand_value = 0.0
+    grand_configured = 0
+    grand_fetched = 0
+    grand_skipped = 0
+    grand_carried = 0
+    for portfolio, holdings in holdings_by_portfolio.items():
+        fresh = fresh_by_portfolio.get(portfolio, [])
+        carried = carried_by_portfolio.get(portfolio, [])
+        skipped = skipped_by_portfolio.get(portfolio, 0)
+        value = float(sum(r.value for r in fresh) + sum(r.value for r in carried))
+        configured = len(holdings)
+        missing = configured - len(fresh) - skipped
+        totals.append(
+            TotalRow(
+                portfolio=portfolio,
+                category=categories.get(portfolio, ""),
+                value=value,
+                symbol_count=configured,
+                missing_symbols=missing,
+                skipped_symbols=skipped,
+                carried_symbols=len(carried),
+                timestamp_ns=timestamp_ns,
+            )
+        )
+        grand_value += value
+        grand_configured += configured
+        grand_fetched += len(fresh)
+        grand_skipped += skipped
+        grand_carried += len(carried)
+
+    totals.append(
+        TotalRow(
+            portfolio="_total",
+            category="",
+            value=grand_value,
+            symbol_count=grand_configured,
+            missing_symbols=grand_configured - grand_fetched - grand_skipped,
+            skipped_symbols=grand_skipped,
+            carried_symbols=grand_carried,
+            timestamp_ns=timestamp_ns,
+        )
+    )
+    return totals
+
+
+def compute_category_totals(
+    portfolio_totals: list[TotalRow],
+    timestamp_ns: int,
+) -> list[CategoryRow]:
+    """Roll up per-portfolio TotalRows into per-category sums.
+
+    Skips:
+      * the `_total` grand-total row (avoids double-counting)
+      * portfolios with no category configured (empty category)
+    """
+    by_category: dict[str, list[TotalRow]] = {}
+    for r in portfolio_totals:
+        if r.portfolio == "_total":
+            continue
+        if not r.category:
+            continue
+        by_category.setdefault(r.category, []).append(r)
+
+    rows: list[CategoryRow] = []
+    for category, ports in by_category.items():
+        rows.append(
+            CategoryRow(
+                category=category,
+                value=float(sum(r.value for r in ports)),
+                symbol_count=sum(r.symbol_count for r in ports),
+                portfolio_count=len(ports),
+                missing_symbols=sum(r.missing_symbols for r in ports),
+                skipped_symbols=sum(r.skipped_symbols for r in ports),
+                carried_symbols=sum(r.carried_symbols for r in ports),
+                timestamp_ns=timestamp_ns,
+            )
+        )
+    return rows
+
+
+def fetch_quote(symbol: str) -> Quote:
+    """Fetch current price + day OHL + previous close + currency for `symbol`.
+
+    Uses yfinance.Ticker(symbol).fast_info — a single HTTP call that returns
+    all the fields the plugin needs. Optional fields default to None when
+    yfinance returns None for them; the caller decides how to handle missing
+    fields when building line protocol.
+
+    Raises ValueError if no last_price is returned. Raises whatever
+    yfinance raises on network/other failures (e.g. requests exceptions).
+
+    yfinance is imported lazily so this module is importable / AST-parseable
+    in environments where yfinance is not installed.
+    """
+    import yfinance as yf
+    ticker = yf.Ticker(symbol)
+    fi = ticker.fast_info
+    if fi.last_price is None:
+        raise ValueError(f"no last_price returned for {symbol}")
+
+    def _opt(attr: str) -> Optional[float]:
+        v = getattr(fi, attr, None)
+        return float(v) if v is not None else None
+
+    try:
+        raw_currency = fi.currency
+    except (KeyError, AttributeError):
+        raw_currency = None
+
+    try:
+        raw_quote_type = fi.quote_type
+    except (KeyError, AttributeError):
+        raw_quote_type = None
+
+    return Quote(
+        symbol=symbol,
+        price=float(fi.last_price),
+        currency=str(raw_currency) if raw_currency else "USD",
+        asset_type=_normalize_quote_type(raw_quote_type),
+        previous_close=_opt("previous_close"),
+        day_open=_opt("open"),
+        day_high=_opt("day_high"),
+        day_low=_opt("day_low"),
+    )
+
+
+def _main(
+    local,
+    args: dict[str, str],
+    fetcher,
+    line_builder_cls,
+    plugin_dir: Path,
+    now_ns: int,
+) -> None:
+    """The core plugin flow. process_scheduled_call delegates here.
+
+    Gating rules applied per symbol:
+      * mutual funds: fetch at most once per configured market calendar day, at the
+        first tick at or after mutual_fund_check_time. Bootstrap exception:
+        if no asset_type has been cached yet, fetch so we can learn the
+        type and record an initial row.
+      * stocks/etfs/other: fetch every tick UNLESS the configured market
+        is closed AND write_during_closed_hours is False.
+      * cold-cache bootstrap: if a symbol would be skipped but has no
+        last_price cached, fetch once so later skipped ticks can carry it.
+
+    Per-symbol asset_type is auto-detected via yfinance.fast_info.quote_type
+    on first fetch and cached (no TTL) so we don't re-query for type.
+    """
+    default_toml = plugin_dir / "stock_plugin.toml"
+    try:
+        config = resolve_config(args, default_toml)
+    except (ValueError, OSError, tomllib.TOMLDecodeError) as e:
+        local.error(f"stock_plugin: configuration error: {e}")
+        return
+
+    market_tz = ZoneInfo(config.market_timezone)
+    now_utc = datetime.fromtimestamp(now_ns / 1_000_000_000, tz=timezone.utc)
+    now_local = now_utc.astimezone(market_tz)
+    today_local = now_local.date().isoformat()
+    try:
+        market_open_now = _is_market_open(
+            now_utc, config.market_calendar, market_tz
+        )
+    except Exception as e:
+        if not config.write_during_closed_hours:
+            local.error(
+                f"stock_plugin: market-calendar lookup failed for "
+                f"{config.market_calendar!r} ({e}); skipping run to avoid "
+                f"fetching during possible closed hours"
+            )
+            return
+        local.warn(
+            f"stock_plugin: market-calendar lookup failed for "
+            f"{config.market_calendar!r} ({e}); continuing because "
+            f"write_during_closed_hours=true"
+        )
+        market_open_now = True
+    mf_check_h, mf_check_m = _parse_hhmm(config.mutual_fund_check_time)
+    mf_check_passed = (now_local.hour, now_local.minute) >= (mf_check_h, mf_check_m)
+
+    total_symbols = sum(len(h) for h in config.holdings_by_portfolio.values())
+    local.info(
+        f"stock_plugin: starting run with {total_symbols} symbol(s) "
+        f"across {len(config.holdings_by_portfolio)} portfolio(s) "
+        f"→ database={config.database}, "
+        f"calendar={config.market_calendar}, market_open={market_open_now}, "
+        f"mf_check_passed={mf_check_passed} (now_local={now_local.isoformat()})"
+    )
+
+    successful: list[HoldingRow] = []
+    failures: list[tuple[str, str]] = []
+    skipped_holdings: list[tuple[Holding, str, str]] = []  # (holding, portfolio, reason)
+    skipped_by_portfolio: dict[str, int] = {}
+    cold_bootstrap_fetches: list[str] = []
+    skip_reasons: dict[str, list[str]] = {
+        "market_closed": [],
+        "mf_already_today": [],
+        "mf_too_early": [],
+    }
+
+    def _record_skip(holding: Holding, portfolio: str, reason: str) -> None:
+        skipped_holdings.append((holding, portfolio, reason))
+        skipped_by_portfolio[portfolio] = (
+            skipped_by_portfolio.get(portfolio, 0) + 1
+        )
+        skip_reasons[reason].append(holding.symbol)
+
+    for portfolio, holdings in config.holdings_by_portfolio.items():
+        for holding in holdings:
+            cached_type = local.cache.get(f"asset_type:{holding.symbol}")
+            skip_reason: Optional[str] = None
+
+            if cached_type == "mutualfund":
+                last_mf_date = local.cache.get(f"last_mf_date:{holding.symbol}")
+                if last_mf_date == today_local:
+                    skip_reason = "mf_already_today"
+                elif not mf_check_passed:
+                    skip_reason = "mf_too_early"
+            elif cached_type in ("equity", "etf", "other"):
+                if not market_open_now and not config.write_during_closed_hours:
+                    skip_reason = "market_closed"
+
+            if (
+                cached_type is None
+                and not market_open_now
+                and not config.write_during_closed_hours
+            ):
+                cold_bootstrap_fetches.append(
+                    f"{holding.symbol}:asset_type_unknown"
+                )
+
+            # Bootstrap: if we would skip but have no cached last_price,
+            # force a fetch this tick so carry-forward will work next time.
+            if (
+                skip_reason is not None
+                and local.cache.get(f"last_price:{holding.symbol}") is None
+            ):
+                cold_bootstrap_fetches.append(f"{holding.symbol}:{skip_reason}")
+                skip_reason = None
+
+            if skip_reason is not None:
+                _record_skip(holding, portfolio, skip_reason)
+                continue
+
+            try:
+                quote = fetcher(holding.symbol)
+            except Exception as e:
+                local.warn(
+                    f"stock_plugin: failed to fetch {holding.symbol}: {e}"
+                )
+                failures.append((holding.symbol, str(e)))
+                continue
+
+            if cached_type != quote.asset_type:
+                local.cache.put(f"asset_type:{holding.symbol}", quote.asset_type)
+            if quote.asset_type == "mutualfund":
+                local.cache.put(f"last_mf_date:{holding.symbol}", today_local)
+            local.cache.put(f"last_price:{holding.symbol}", float(quote.price))
+
+            successful.append(
+                HoldingRow(
+                    symbol=holding.symbol,
+                    portfolio=portfolio,
+                    asset_type=quote.asset_type,
+                    category=config.categories.get(portfolio, ""),
+                    price=quote.price,
+                    quantity=holding.quantity,
+                    value=quote.price * holding.quantity,
+                    currency=quote.currency,
+                    previous_close=quote.previous_close,
+                    day_open=quote.day_open,
+                    day_high=quote.day_high,
+                    day_low=quote.day_low,
+                    timestamp_ns=now_ns,
+                )
+            )
+
+    carried: list[HoldingRow] = []
+    for holding, portfolio, _reason in skipped_holdings:
+        last_price = local.cache.get(f"last_price:{holding.symbol}")
+        if last_price is None:
+            continue
+        last_price = float(last_price)
+        cached_type = local.cache.get(f"asset_type:{holding.symbol}") or "other"
+        carried.append(
+            HoldingRow(
+                symbol=holding.symbol,
+                portfolio=portfolio,
+                asset_type=cached_type,
+                category=config.categories.get(portfolio, ""),
+                price=last_price,
+                quantity=holding.quantity,
+                value=last_price * holding.quantity,
+                currency="USD",
+                previous_close=None,
+                day_open=None,
+                day_high=None,
+                day_low=None,
+                timestamp_ns=now_ns,
+            )
+        )
+
+    totals = compute_totals(
+        config.holdings_by_portfolio,
+        config.categories,
+        successful,
+        carried,
+        skipped_by_portfolio,
+        now_ns,
+    )
+    category_totals = compute_category_totals(totals, now_ns)
+
+    for r in successful:
+        lb = line_builder_cls("stock_holdings")
+        lb.tag("symbol", r.symbol)
+        lb.tag("portfolio", r.portfolio)
+        lb.tag("asset_type", r.asset_type)
+        if r.category:
+            lb.tag("category", r.category)
+        lb.float64_field("price", r.price)
+        lb.float64_field("quantity", r.quantity)
+        lb.float64_field("value", r.value)
+        lb.string_field("currency", r.currency)
+        if r.previous_close is not None:
+            lb.float64_field("previous_close", r.previous_close)
+        if r.day_open is not None:
+            lb.float64_field("day_open", r.day_open)
+        if r.day_high is not None:
+            lb.float64_field("day_high", r.day_high)
+        if r.day_low is not None:
+            lb.float64_field("day_low", r.day_low)
+        lb.time_ns(r.timestamp_ns)
+        local.write_to_db(config.database, lb)
+
+    for t in totals:
+        lb = line_builder_cls("portfolio_totals")
+        lb.tag("portfolio", t.portfolio)
+        if t.category:
+            lb.tag("category", t.category)
+        lb.float64_field("value", t.value)
+        lb.int64_field("symbol_count", t.symbol_count)
+        lb.int64_field("missing_symbols", t.missing_symbols)
+        lb.int64_field("skipped_symbols", t.skipped_symbols)
+        lb.int64_field("carried_symbols", t.carried_symbols)
+        lb.time_ns(t.timestamp_ns)
+        local.write_to_db(config.database, lb)
+
+    for c in category_totals:
+        lb = line_builder_cls("category_totals")
+        lb.tag("category", c.category)
+        lb.float64_field("value", c.value)
+        lb.int64_field("symbol_count", c.symbol_count)
+        lb.int64_field("portfolio_count", c.portfolio_count)
+        lb.int64_field("missing_symbols", c.missing_symbols)
+        lb.int64_field("skipped_symbols", c.skipped_symbols)
+        lb.int64_field("carried_symbols", c.carried_symbols)
+        lb.time_ns(c.timestamp_ns)
+        local.write_to_db(config.database, lb)
+
+    skipped_total = sum(skipped_by_portfolio.values())
+    parts = [f"fetched {len(successful)}/{total_symbols} symbols"]
+    if skipped_total:
+        skip_bits = []
+        if skip_reasons["market_closed"]:
+            skip_bits.append(f"{len(skip_reasons['market_closed'])} market-closed")
+        if skip_reasons["mf_already_today"]:
+            skip_bits.append(
+                f"{len(skip_reasons['mf_already_today'])} mutual-fund-already-today"
+            )
+        if skip_reasons["mf_too_early"]:
+            skip_bits.append(
+                f"{len(skip_reasons['mf_too_early'])} mutual-fund-too-early"
+            )
+        parts.append(f"skipped {skipped_total} ({', '.join(skip_bits)})")
+    if carried:
+        parts.append(f"carried last-known value for {len(carried)} skipped")
+    if cold_bootstrap_fetches:
+        parts.append(
+            f"attempted {len(cold_bootstrap_fetches)} cold-cache bootstrap fetches"
+        )
+    parts.append(
+        f"wrote {len(successful)} holding rows + {len(totals)} portfolio_total rows "
+        f"({len(totals) - 1} portfolios + grand total) + "
+        f"{len(category_totals)} category_total rows to {config.database}"
+    )
+    if failures:
+        parts.append(
+            "Failed: " + ", ".join(f"{s} ({e})" for s, e in failures)
+        )
+    local.info("stock_plugin: " + ". ".join(parts))
+
+
+def process_scheduled_call(influxdb3_local, call_time, args):
+    """Scheduled plugin entry point invoked by InfluxDB 3.
+
+    We stamp every row in this run with one consistent UTC timestamp so
+    per-symbol holdings, portfolio_totals, and category_totals line up
+    cleanly when joined in queries.
+
+    We deliberately ignore the passed-in `call_time` for timestamping.
+    Empirically, `call_time` can arrive as a naive datetime in server
+    local time (not UTC) on some deployments, which would silently
+    shift every row by the server's UTC offset. `datetime.now(timezone.utc)`
+    is unambiguous regardless of host timezone; the few-seconds offset
+    from the scheduled tick boundary is negligible for a 15-minute
+    polling cadence.
+
+    The InfluxDB runtime executes plugins via exec(), so __file__ is not
+    defined. INFLUXDB3_PLUGIN_DIR is the env var the server itself uses
+    to locate the plugin directory.
+    """
+    plugin_dir = Path(os.environ.get("INFLUXDB3_PLUGIN_DIR", "."))
+    now_ns = int(datetime.now(timezone.utc).timestamp() * 1_000_000_000)
+    _main(
+        local=influxdb3_local,
+        args=args or {},
+        fetcher=fetch_quote,
+        line_builder_cls=LineBuilder,  # runtime-injected global
+        plugin_dir=plugin_dir,
+        now_ns=now_ns,
+    )

--- a/influxdata/stock_plugin/stock_plugin.py
+++ b/influxdata/stock_plugin/stock_plugin.py
@@ -1,40 +1,40 @@
-"""InfluxDB 3 Processing Engine plugin: stock portfolio tracker.
-
-Scheduled plugin that fetches stock prices from Yahoo Finance (via
-yfinance) and writes per-symbol holdings plus per-portfolio totals to
-InfluxDB. Trigger cadence is controlled by the Processing Engine trigger
-spec, typically `every:15m`.
-
-Per-symbol fetch gating:
-  * stocks/etfs: fetched every tick UNLESS write_during_closed_hours is
-    false AND the configured market (default NYSE) regular session is
-    currently closed. Market hours come from pandas_market_calendars
-    (handles holidays and early closes). Set market_calendar and
-    market_timezone in TOML to gate against a non-US exchange (LSE,
-    JPX, TSX, XETR, etc.).
-  * mutual funds: fetched at most once per local calendar day, at the
-    first tick at or after mutual_fund_check_time. Bootstrap exception:
-    a mutual fund with no cached asset_type is fetched on its first tick
-    regardless of time so the plugin can learn its type and record an
-    initial row.
-  * cold-cache bootstrap: if a symbol would be skipped but has no cached
-    last price, it is fetched once so carry-forward totals can work on
-    later skipped ticks.
-
-Per-symbol asset_type is detected from yfinance.fast_info.quote_type on
-first fetch and cached (no TTL) in influxdb3_local.cache.
-
-The InfluxDB runtime injects `influxdb3_local` and `LineBuilder` as
-globals. These are referenced ONLY inside process_scheduled_call (and
-_main, which takes them as parameters). The module imports cleanly in
-plain Python; yfinance and pandas_market_calendars are imported lazily
-inside the functions that use them.
+"""
+{
+    "plugin_type": ["scheduled"],
+    "scheduled_args_config": [
+        {
+            "name": "database",
+            "example": "stocks",
+            "description": "Target database for writes. Overrides the TOML database key if both are set. Defaults to stocks.",
+            "required": false
+        },
+        {
+            "name": "portfolio",
+            "example": "AAPL:10:401k|MSFT:5:401k|GOOG:2.5:brokerage",
+            "description": "Inline holdings as pipe-separated SYMBOL:QUANTITY[:PORTFOLIO_NAME] entries. Required unless config_path points to a TOML file with holdings.",
+            "required": false
+        },
+        {
+            "name": "categories",
+            "example": "401k:Retirement|brokerage:Investment",
+            "description": "Inline category map as pipe-separated PORTFOLIO:CATEGORY entries.",
+            "required": false
+        },
+        {
+            "name": "config_path",
+            "example": "stock_plugin.toml",
+            "description": "Path to TOML configuration file. Supports absolute paths or relative paths resolved from INFLUXDB3_PLUGIN_DIR, PLUGIN_DIR, VIRTUAL_ENV parent, or the plugin directory.",
+            "required": false
+        }
+    ]
+}
 """
 
 from __future__ import annotations
 
 import os
 import tomllib
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -420,8 +420,6 @@ def resolve_config(
     Other TOML scalars (write_during_closed_hours, mutual_fund_check_time,
     market_calendar, market_timezone) come only from TOML — there is no
     inline-arg override for them. Defaults apply when the key is absent.
-    Legacy `stock_interval_minutes`, if present, is ignored; the trigger
-    spec controls cadence.
 
     Raises ValueError if neither inline holdings nor a usable TOML file is
     found, or if any TOML scalar has an invalid value.
@@ -674,6 +672,7 @@ def _main(
     line_builder_cls,
     plugin_dir: Path,
     now_ns: int,
+    task_id: str,
 ) -> None:
     """The core plugin flow. process_scheduled_call delegates here.
 
@@ -694,7 +693,7 @@ def _main(
     try:
         config = resolve_config(args, default_toml)
     except (ValueError, OSError, tomllib.TOMLDecodeError) as e:
-        local.error(f"stock_plugin: configuration error: {e}")
+        local.error(f"[{task_id}] stock_plugin: configuration error: {e}")
         return
 
     market_tz = ZoneInfo(config.market_timezone)
@@ -708,13 +707,13 @@ def _main(
     except Exception as e:
         if not config.write_during_closed_hours:
             local.error(
-                f"stock_plugin: market-calendar lookup failed for "
+                f"[{task_id}] stock_plugin: market-calendar lookup failed for "
                 f"{config.market_calendar!r} ({e}); skipping run to avoid "
                 f"fetching during possible closed hours"
             )
             return
         local.warn(
-            f"stock_plugin: market-calendar lookup failed for "
+            f"[{task_id}] stock_plugin: market-calendar lookup failed for "
             f"{config.market_calendar!r} ({e}); continuing because "
             f"write_during_closed_hours=true"
         )
@@ -724,7 +723,7 @@ def _main(
 
     total_symbols = sum(len(h) for h in config.holdings_by_portfolio.values())
     local.info(
-        f"stock_plugin: starting run with {total_symbols} symbol(s) "
+        f"[{task_id}] stock_plugin: starting run with {total_symbols} symbol(s) "
         f"across {len(config.holdings_by_portfolio)} portfolio(s) "
         f"→ database={config.database}, "
         f"calendar={config.market_calendar}, market_open={market_open_now}, "
@@ -790,7 +789,7 @@ def _main(
                 quote = fetcher(holding.symbol)
             except Exception as e:
                 local.warn(
-                    f"stock_plugin: failed to fetch {holding.symbol}: {e}"
+                    f"[{task_id}] stock_plugin: failed to fetch {holding.symbol}: {e}"
                 )
                 failures.append((holding.symbol, str(e)))
                 continue
@@ -931,7 +930,7 @@ def _main(
         parts.append(
             "Failed: " + ", ".join(f"{s} ({e})" for s, e in failures)
         )
-    local.info("stock_plugin: " + ". ".join(parts))
+    local.info(f"[{task_id}] stock_plugin: " + ". ".join(parts))
 
 
 def process_scheduled_call(influxdb3_local, call_time, args):
@@ -955,6 +954,7 @@ def process_scheduled_call(influxdb3_local, call_time, args):
     """
     plugin_dir = Path(os.environ.get("INFLUXDB3_PLUGIN_DIR", "."))
     now_ns = int(datetime.now(timezone.utc).timestamp() * 1_000_000_000)
+    task_id = uuid.uuid4().hex[:8]
     _main(
         local=influxdb3_local,
         args=args or {},
@@ -962,4 +962,5 @@ def process_scheduled_call(influxdb3_local, call_time, args):
         line_builder_cls=LineBuilder,  # runtime-injected global
         plugin_dir=plugin_dir,
         now_ns=now_ns,
+        task_id=task_id,
     )

--- a/influxdata/stock_plugin/stock_plugin.toml.example
+++ b/influxdata/stock_plugin/stock_plugin.toml.example
@@ -1,0 +1,56 @@
+# Example stock_plugin configuration.
+# Copy to stock_plugin.toml in your InfluxDB plugin directory.
+
+# Target database for writes. Optional — defaults to "stocks".
+# Overridden by --trigger-arguments database=... if set.
+database = "stocks"
+
+# Write rows even when US markets are closed? When false, stocks/ETFs
+# are skipped outside 9:30-16:00 ET on weekdays (and on US market
+# holidays). If the cache is cold, the plugin may fetch once anyway to
+# seed a last-known price for future carry-forward totals. Defaults to true.
+write_during_closed_hours = true
+
+# Time of day (in market_timezone, below) after which to fetch mutual fund
+# NAV. Mutual funds get fetched at most once per local calendar day, at
+# the first trigger tick at or after this time. Bootstrap exception: a
+# mutual fund with no asset_type cached yet is fetched on the next tick
+# regardless of time, so the plugin can learn its type and write an
+# initial row. Defaults to "18:00".
+mutual_fund_check_time = "18:00"
+
+# Stock exchange whose calendar governs the market-open check. Any name
+# accepted by pandas_market_calendars works (NYSE, LSE, TSX, JPX, XETR,
+# etc. — see https://pandas-market-calendars.readthedocs.io/ for the
+# full list). The timezone below should be the exchange's local time.
+# Defaults: NYSE / America/New_York.
+market_calendar = "NYSE"
+market_timezone = "America/New_York"
+
+# Optional: assign each portfolio to a user-defined category. Categories
+# roll up into a separate category_totals measurement so you can see
+# things like "total retirement value" at a glance. Portfolios not
+# listed here are uncategorized (omitted from category_totals).
+[portfolio_categories]
+"401k" = "Retirement"
+brokerage = "Investment"
+
+# Holdings, grouped by portfolio name.
+# Each [holdings.<portfolio_name>] table is a {symbol = quantity} mapping.
+# Fractional quantities are supported. Quote ticker symbols that contain
+# dots; unquoted dots are TOML nested-key syntax, not literal symbol text.
+# Duplicate same-symbol entries in one portfolio are aggregated.
+
+[holdings.401k]
+AAPL = 10
+MSFT = 5
+
+[holdings.brokerage]
+GOOG = 2.5
+TSLA = 3
+"VOD.L" = 10
+
+# If you only have one portfolio, pick any name for it:
+# [holdings.main]
+# AAPL = 10
+# "BRK.B" = 1


### PR DESCRIPTION
## Summary
- add the Stock Portfolio Tracker plugin under influxdata/stock_plugin
- keep manifest database version at InfluxDB 3 >=3.0.0 because it does not use write_sync/write_sync_to_db
- add the beta plugin_library.json entry
- update copied README to satisfy required repository sections and current --path syntax

## Validation
- python3 scripts/validate_readme.py --plugins stock_plugin
- python3 scripts/validate_influxdb3_syntax.py --readme /Users/rcater/Repos/LibrarySrc/influxdb3_plugins/influxdata/stock_plugin/README.md --errors-only
- python3 -m py_compile influxdata/stock_plugin/stock_plugin.py