### PR TITLE
feat: resolve relative config paths via server-derivable fallbacks

### DIFF
--- a/influxdata/amqp_subscriber/amqp_subscriber.py
+++ b/influxdata/amqp_subscriber/amqp_subscriber.py
@@ -141,6 +141,7 @@ import time
 import tomllib
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 import pika
@@ -191,17 +192,33 @@ class _BatchLines:
 
 
 def _resolve_path(path: str, description: str) -> str:
-    """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR."""
+    """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR, falling back to server-derivable locations."""
     if os.path.isabs(path):
         return path
 
     plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
-    if not plugin_dir:
-        raise ValueError(
-            f"PLUGIN_DIR environment variable not set. "
-            f"Required for relative {description} path."
-        )
-    return os.path.join(plugin_dir, path)
+    if plugin_dir:
+        return os.path.join(plugin_dir, path)
+
+    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+    candidates: list[str] = []
+    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+        candidates.append(influxdb3_plugin_dir)
+    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+        candidates.append(str(Path(virtual_env).parent))
+
+    for base in candidates:
+        candidate = os.path.join(base, path)
+        if os.path.exists(candidate):
+            return candidate
+
+    raise ValueError(
+        f"PLUGIN_DIR environment variable not set and {description} path "
+        f"'{path}' was not found via fallbacks "
+        f"(tried: {', '.join(candidates) or 'none available'})."
+    )
 
 
 def add_field_with_type(line, field_key: str, value: Any, field_type: str):

--- a/influxdata/amqp_subscriber/manifest.toml
+++ b/influxdata/amqp_subscriber/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "amqp_subscriber"
-version = "0.1.0"
+version = "0.2.0"
 description = "Enables real-time ingestion of AMQP messages into InfluxDB 3. Subscribe to queues and transform messages into time-series data with support for JSON, Line Protocol, and custom text formats."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/basic_transformation/basic_transformation.py
+++ b/influxdata/basic_transformation/basic_transformation.py
@@ -1443,13 +1443,33 @@ def process_scheduled_call(
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)
@@ -1796,16 +1816,33 @@ def process_writes(influxdb3_local, table_batches: list, args: dict | None = Non
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                influxdb3_local.info(
-                    f"[{task_id}] PLUGIN_DIR env var is set"
-                )
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/basic_transformation/manifest.toml
+++ b/influxdata/basic_transformation/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "basic_transformation"
-version = "1.0.0"
+version = "1.1.0"
 description = "Enables transformation of time series data stored in InfluxDB 3 (transformations are supported for field/tag names and values)."
 triggers = ["process_writes", "process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/downsampler/downsampler.py
+++ b/influxdata/downsampler/downsampler.py
@@ -1200,13 +1200,33 @@ def process_scheduled_call(
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/downsampler/manifest.toml
+++ b/influxdata/downsampler/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "downsampler"
-version = "1.0.0"
+version = "1.1.0"
 description = "Enables downsampling of data in InfluxDB 3 with flexible configuration for time intervals, field aggregations, tag filtering, and batch processing. Supports scheduler and HTTP trigger modes."
 triggers = ["process_scheduled_call", "process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/forecast_error_evaluator/forecast_error_evaluator.py
+++ b/influxdata/forecast_error_evaluator/forecast_error_evaluator.py
@@ -631,13 +631,33 @@ def process_scheduled_call(
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/forecast_error_evaluator/manifest.toml
+++ b/influxdata/forecast_error_evaluator/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "forecast_error_evaluator"
-version = "1.0.0"
+version = "1.1.0"
 description = "Evaluates accuracy of forecast models by comparing predicted values with actual observations. Computes error metrics and detects anomalies based on elevated errors with multi-channel notifications."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/import/import.py
+++ b/influxdata/import/import.py
@@ -239,14 +239,35 @@ def load_config(
             raise Exception("Invalid config file format: expected a .toml file")
 
         plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-        if not plugin_dir_var:
-            influxdb3_local.error(f"[{task_id}] Failed to get PLUGIN_DIR env var")
-            raise Exception("PLUGIN_DIR environment variable not set")
+        if plugin_dir_var:
+            config_file = Path(plugin_dir_var) / config_file_path
+        else:
+            # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+            #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+            #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+            candidates: list[str] = []
+            if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                candidates.append(influxdb3_plugin_dir)
+            if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                candidates.append(str(Path(virtual_env).parent))
+
+            resolved = None
+            for base in candidates:
+                candidate = Path(base) / config_file_path
+                if candidate.exists():
+                    resolved = candidate
+                    break
+
+            if resolved is None:
+                candidates_str = ", ".join(candidates) if candidates else "none available"
+                influxdb3_local.error(
+                    f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                    f"'{config_file_path}' was not found via fallbacks (tried: {candidates_str})"
+                )
+                raise Exception("PLUGIN_DIR environment variable not set")
+            config_file = resolved
 
         try:
-            plugin_dir: Path = Path(plugin_dir_var)
-            config_file = plugin_dir / config_file_path
-
             with open(config_file, "rb") as f:
                 file_config = tomllib.load(f)
             # Override config_data with values from file

--- a/influxdata/import/manifest.toml
+++ b/influxdata/import/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "import"
-version = "0.1.0"
+version = "0.2.0"
 description = "Enables seamless data import from InfluxDB v1, v2, or v3 instances to InfluxDB 3 Core/Enterprise"
 triggers = ["process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/influxdb_to_iceberg/influxdb_to_iceberg.py
+++ b/influxdata/influxdb_to_iceberg/influxdb_to_iceberg.py
@@ -447,13 +447,33 @@ def process_scheduled_call(
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/influxdb_to_iceberg/manifest.toml
+++ b/influxdata/influxdb_to_iceberg/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "influxdb_to_iceberg"
-version = "1.0.0"
+version = "1.1.0"
 description = "Transfers data from InfluxDB 3 to Apache Iceberg tables with automatic schema management, customizable namespace and table naming, field filtering, and batch processing support."
 triggers = ["process_scheduled_call", "process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/kafka_subscriber/kafka_subscriber.py
+++ b/influxdata/kafka_subscriber/kafka_subscriber.py
@@ -146,6 +146,7 @@ import time
 import tomllib
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from confluent_kafka import Consumer, KafkaError, KafkaException, TopicPartition
@@ -295,17 +296,33 @@ class KafkaConfig:
 
     @staticmethod
     def _resolve_path(path: str, description: str) -> str:
-        """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR."""
+        """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR, falling back to server-derivable locations."""
         if os.path.isabs(path):
             return path
 
         plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
-        if not plugin_dir:
-            raise ValueError(
-                f"PLUGIN_DIR environment variable not set. "
-                f"Required for relative {description} path."
-            )
-        return os.path.join(plugin_dir, path)
+        if plugin_dir:
+            return os.path.join(plugin_dir, path)
+
+        # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+        #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+        #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+        candidates: list[str] = []
+        if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+            candidates.append(influxdb3_plugin_dir)
+        if virtual_env := os.environ.get("VIRTUAL_ENV"):
+            candidates.append(str(Path(virtual_env).parent))
+
+        for base in candidates:
+            candidate = os.path.join(base, path)
+            if os.path.exists(candidate):
+                return candidate
+
+        raise ValueError(
+            f"PLUGIN_DIR environment variable not set and {description} path "
+            f"'{path}' was not found via fallbacks "
+            f"(tried: {', '.join(candidates) or 'none available'})."
+        )
 
     @staticmethod
     def _validate_topics(topics: list) -> None:
@@ -898,17 +915,33 @@ class KafkaConsumerManager:
 
     @staticmethod
     def _resolve_path(path: str, description: str) -> str:
-        """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR."""
+        """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR, falling back to server-derivable locations."""
         if os.path.isabs(path):
             return path
 
         plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
-        if not plugin_dir:
-            raise ValueError(
-                f"PLUGIN_DIR environment variable not set. "
-                f"Required for relative {description} path."
-            )
-        return os.path.join(plugin_dir, path)
+        if plugin_dir:
+            return os.path.join(plugin_dir, path)
+
+        # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+        #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+        #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+        candidates: list[str] = []
+        if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+            candidates.append(influxdb3_plugin_dir)
+        if virtual_env := os.environ.get("VIRTUAL_ENV"):
+            candidates.append(str(Path(virtual_env).parent))
+
+        for base in candidates:
+            candidate = os.path.join(base, path)
+            if os.path.exists(candidate):
+                return candidate
+
+        raise ValueError(
+            f"PLUGIN_DIR environment variable not set and {description} path "
+            f"'{path}' was not found via fallbacks "
+            f"(tried: {', '.join(candidates) or 'none available'})."
+        )
 
     def _build_consumer_config(self) -> dict[str, Any]:
         """Build confluent-kafka consumer configuration dictionary"""

--- a/influxdata/kafka_subscriber/manifest.toml
+++ b/influxdata/kafka_subscriber/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "kafka_subscriber"
-version = "0.1.0"
+version = "0.2.0"
 description = "Enables real-time ingestion of Kafka messages into InfluxDB 3. Subscribe to Kafka topics and transform messages into time-series data with support for JSON, Line Protocol, and custom text formats."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/mad_check/mad_check_plugin.py
+++ b/influxdata/mad_check/mad_check_plugin.py
@@ -672,13 +672,33 @@ def process_writes(influxdb3_local, table_batches: list, args: dict | None = Non
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/mad_check/manifest.toml
+++ b/influxdata/mad_check/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "mad_check"
-version = "1.0.0"
+version = "1.1.0"
 description = "Provides Median Absolute Deviation (MAD)-based anomaly detection using data writes trigger. Maintains in-memory deques for efficient computation and supports count-based and duration-based thresholds."
 triggers = ["process_writes"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/mqtt_subscriber/manifest.toml
+++ b/influxdata/mqtt_subscriber/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "mqtt_subscriber"
-version = "0.1.0"
+version = "0.2.0"
 description = "Enables real-time ingestion of MQTT messages into InfluxDB 3. Subscribe to MQTT topics and transform messages into time-series data with support for JSON, Line Protocol, and custom text formats."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/mqtt_subscriber/mqtt_subscriber.py
+++ b/influxdata/mqtt_subscriber/mqtt_subscriber.py
@@ -133,6 +133,7 @@ import time
 import tomllib
 import uuid
 from datetime import datetime
+from pathlib import Path
 from queue import Empty, Queue
 from typing import Any, Protocol, runtime_checkable
 
@@ -323,12 +324,28 @@ class MQTTConfig:
             return path
 
         plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
-        if not plugin_dir:
-            raise ValueError(
-                f"PLUGIN_DIR environment variable not set. "
-                f"Required for relative {description} path."
-            )
-        return os.path.join(plugin_dir, path)
+        if plugin_dir:
+            return os.path.join(plugin_dir, path)
+
+        # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+        #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+        #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+        candidates: list[str] = []
+        if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+            candidates.append(influxdb3_plugin_dir)
+        if virtual_env := os.environ.get("VIRTUAL_ENV"):
+            candidates.append(str(Path(virtual_env).parent))
+
+        for base in candidates:
+            candidate = os.path.join(base, path)
+            if os.path.exists(candidate):
+                return candidate
+
+        raise ValueError(
+            f"PLUGIN_DIR environment variable not set and {description} path "
+            f"'{path}' was not found via fallbacks "
+            f"(tried: {', '.join(candidates) or 'none available'})."
+        )
 
     @staticmethod
     def _validate_secure_auth(mqtt_config: dict[str, Any]):
@@ -956,12 +973,28 @@ class MQTTConnectionManager:
             return path
 
         plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
-        if not plugin_dir:
-            raise ValueError(
-                f"PLUGIN_DIR environment variable not set. "
-                f"Required for relative {description} path."
-            )
-        return os.path.join(plugin_dir, path)
+        if plugin_dir:
+            return os.path.join(plugin_dir, path)
+
+        # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+        #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+        #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+        candidates: list[str] = []
+        if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+            candidates.append(influxdb3_plugin_dir)
+        if virtual_env := os.environ.get("VIRTUAL_ENV"):
+            candidates.append(str(Path(virtual_env).parent))
+
+        for base in candidates:
+            candidate = os.path.join(base, path)
+            if os.path.exists(candidate):
+                return candidate
+
+        raise ValueError(
+            f"PLUGIN_DIR environment variable not set and {description} path "
+            f"'{path}' was not found via fallbacks "
+            f"(tried: {', '.join(candidates) or 'none available'})."
+        )
 
     def _configure_tls(self, tls_config: dict[str, Any]):
         """Configure TLS/SSL for the MQTT client"""

--- a/influxdata/opcua/manifest.toml
+++ b/influxdata/opcua/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "opcua"
-version = "0.1.0"
+version = "0.2.0"
 description = "Enables periodic ingestion of OPC UA node values into InfluxDB 3. Connect to OPC UA servers and read current values with auto-discovery browse mode, data type detection, and namespace resolution."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/opcua/opcua.py
+++ b/influxdata/opcua/opcua.py
@@ -164,6 +164,7 @@ import time
 import tomllib
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
@@ -261,17 +262,33 @@ def _classify_quality(sc_value: int) -> str:
 
 
 def _resolve_path(path: str, description: str) -> str:
-    """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR."""
+    """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR, falling back to server-derivable locations."""
     if os.path.isabs(path):
         return path
 
     plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
-    if not plugin_dir:
-        raise ValueError(
-            f"PLUGIN_DIR environment variable not set. "
-            f"Required for relative {description} path."
-        )
-    return os.path.join(plugin_dir, path)
+    if plugin_dir:
+        return os.path.join(plugin_dir, path)
+
+    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+    candidates: list[str] = []
+    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+        candidates.append(influxdb3_plugin_dir)
+    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+        candidates.append(str(Path(virtual_env).parent))
+
+    for base in candidates:
+        candidate = os.path.join(base, path)
+        if os.path.exists(candidate):
+            return candidate
+
+    raise ValueError(
+        f"PLUGIN_DIR environment variable not set and {description} path "
+        f"'{path}' was not found via fallbacks "
+        f"(tried: {', '.join(candidates) or 'none available'})."
+    )
 
 
 def add_field_with_type(line, field_key: str, value: Any, field_type: str):

--- a/influxdata/prophet_forecasting/manifest.toml
+++ b/influxdata/prophet_forecasting/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "prophet_forecasting"
-version = "1.0.0"
+version = "1.1.0"
 description = "Provides time series forecasting capabilities for InfluxDB 3 data using the Prophet library."
 triggers = ["process_scheduled_call", "process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/prophet_forecasting/prophet_forecasting.py
+++ b/influxdata/prophet_forecasting/prophet_forecasting.py
@@ -1007,13 +1007,33 @@ def process_scheduled_call(
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/river_anomaly_detector/manifest.toml
+++ b/influxdata/river_anomaly_detector/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "river_anomaly_detector"
-version = "0.1.0"
+version = "0.2.0"
 description = "Detects time-series anomalies on writes using River ML models, combining rolling statistics with HalfSpaceTrees for per-series anomaly scoring and optional auto-tuning from River Auto Profiler output."
 triggers = ["process_writes"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/river_anomaly_detector/river_anomaly_detector.py
+++ b/influxdata/river_anomaly_detector/river_anomaly_detector.py
@@ -189,11 +189,32 @@ def load_detector_toml_config(influxdb3_local, args: dict, task_id: str) -> dict
         else:
             plugin_dir_var = os.getenv("PLUGIN_DIR", None)
             if not plugin_dir_var:
-                influxdb3_local.error(
-                    f"[{task_id}] PLUGIN_DIR env var not set and config_file_path is relative"
-                )
-                return None
-            file_path = Path(plugin_dir_var) / path
+                # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                candidates: list[str] = []
+                if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                    candidates.append(influxdb3_plugin_dir)
+                if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                    candidates.append(str(Path(virtual_env).parent))
+
+                resolved = None
+                for base in candidates:
+                    candidate = os.path.join(base, path)
+                    if os.path.exists(candidate):
+                        resolved = candidate
+                        break
+
+                if resolved:
+                    file_path = Path(resolved)
+                else:
+                    candidates_str = ", ".join(candidates) if candidates else "none available"
+                    influxdb3_local.error(
+                        f"[{task_id}] PLUGIN_DIR env var not set and config_file_path '{path}' was not found via fallbacks (tried: {candidates_str})"
+                    )
+                    return None
+            else:
+                file_path = Path(plugin_dir_var) / path
         influxdb3_local.info(f"[{task_id}] Reading config from {file_path}")
         with open(file_path, "rb") as f:
             return tomllib.load(f)

--- a/influxdata/river_auto_profiler/manifest.toml
+++ b/influxdata/river_auto_profiler/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "river_auto_profiler"
-version = "0.1.0"
+version = "0.2.0"
 description = "Incrementally profiles time-series data with River ML streaming statistics and writes per-series recommendations for anomaly detection tuning, including thresholds, fading factors, and maturity."
 triggers = ["process_writes"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/river_auto_profiler/river_auto_profiler.py
+++ b/influxdata/river_auto_profiler/river_auto_profiler.py
@@ -129,11 +129,32 @@ def load_profiler_toml_config(influxdb3_local, args: dict, task_id: str) -> dict
         else:
             plugin_dir_var = os.getenv("PLUGIN_DIR", None)
             if not plugin_dir_var:
-                influxdb3_local.error(
-                    f"[{task_id}] PLUGIN_DIR env var not set and config_file_path is relative"
-                )
-                return None
-            file_path = Path(plugin_dir_var) / path
+                # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                candidates: list[str] = []
+                if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                    candidates.append(influxdb3_plugin_dir)
+                if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                    candidates.append(str(Path(virtual_env).parent))
+
+                resolved = None
+                for base in candidates:
+                    candidate = os.path.join(base, path)
+                    if os.path.exists(candidate):
+                        resolved = candidate
+                        break
+
+                if resolved:
+                    file_path = Path(resolved)
+                else:
+                    candidates_str = ", ".join(candidates) if candidates else "none available"
+                    influxdb3_local.error(
+                        f"[{task_id}] PLUGIN_DIR env var not set and config_file_path '{path}' was not found via fallbacks (tried: {candidates_str})"
+                    )
+                    return None
+            else:
+                file_path = Path(plugin_dir_var) / path
         influxdb3_local.info(f"[{task_id}] Reading config from {file_path}")
         with open(file_path, "rb") as f:
             return tomllib.load(f)

--- a/influxdata/river_forecaster/manifest.toml
+++ b/influxdata/river_forecaster/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "river_forecaster"
-version = "0.1.0"
+version = "0.2.0"
 description = "Provides online time-series forecasting with River ML SNARIMAX models, learning from writes and producing scheduled multi-step forecasts with per-series model state and optional auto-horizon support."
 triggers = ["process_writes"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/river_forecaster/river_forecaster.py
+++ b/influxdata/river_forecaster/river_forecaster.py
@@ -141,12 +141,34 @@ def forecaster_load_toml_config(
             file_path = Path(path)
         else:
             plugin_dir_var = os.getenv("PLUGIN_DIR", None)
-            if not plugin_dir_var:
-                influxdb3_local.error(
-                    f"[{task_id}] PLUGIN_DIR env var not set and config_file_path is relative"
-                )
-                return None
-            file_path = Path(plugin_dir_var) / path
+            if plugin_dir_var:
+                file_path = Path(plugin_dir_var) / path
+            else:
+                # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                candidates: list[str] = []
+                if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                    candidates.append(influxdb3_plugin_dir)
+                if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                    candidates.append(str(Path(virtual_env).parent))
+
+                resolved = None
+                for base in candidates:
+                    candidate = os.path.join(base, path)
+                    if os.path.exists(candidate):
+                        resolved = candidate
+                        break
+
+                if resolved:
+                    file_path = Path(resolved)
+                else:
+                    candidates_str = ", ".join(candidates) if candidates else "none available"
+                    influxdb3_local.error(
+                        f"[{task_id}] PLUGIN_DIR env var not set and config_file_path '{path}' "
+                        f"was not found via fallbacks (tried: {candidates_str})"
+                    )
+                    return None
         influxdb3_local.info(f"[{task_id}] Reading config from {file_path}")
         with open(file_path, "rb") as f:
             return tomllib.load(f)

--- a/influxdata/sagemaker/manifest.toml
+++ b/influxdata/sagemaker/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "sagemaker"
-version = "0.1.0"
+version = "0.2.0"
 description = "Runs scheduled inference against Amazon SageMaker endpoints using recent InfluxDB 3 rows and writes prediction results back to InfluxDB."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/sagemaker/sagemaker.py
+++ b/influxdata/sagemaker/sagemaker.py
@@ -130,6 +130,7 @@ import time
 import tomllib
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 import boto3
@@ -1214,18 +1215,30 @@ class SageMakerConfig:
     @staticmethod
     def _resolve_path(path: str, description: str) -> str:
         """Resolve path — absolute as-is, relative resolved from the plugin dir
-        (INFLUXDB3_PLUGIN_DIR or PLUGIN_DIR)."""
+        (INFLUXDB3_PLUGIN_DIR or PLUGIN_DIR), falling back to server-derivable
+        locations."""
         if os.path.isabs(path):
             return path
         plugin_dir: str | None = os.environ.get(
             "INFLUXDB3_PLUGIN_DIR"
         ) or os.environ.get("PLUGIN_DIR")
-        if not plugin_dir:
-            raise ValueError(
-                f"Neither INFLUXDB3_PLUGIN_DIR nor PLUGIN_DIR environment "
-                f"variable is set. Required for relative {description} path."
-            )
-        return os.path.join(plugin_dir, path)
+        if plugin_dir:
+            return os.path.join(plugin_dir, path)
+
+        # Fallback for servers where neither variable is present in the
+        # process environment: VIRTUAL_ENV is exported by the processing
+        # engine and its default venv location is <plugin-dir>/.venv.
+        if virtual_env := os.environ.get("VIRTUAL_ENV"):
+            candidate = os.path.join(str(Path(virtual_env).parent), path)
+            if os.path.exists(candidate):
+                return candidate
+
+        raise ValueError(
+            f"Neither INFLUXDB3_PLUGIN_DIR nor PLUGIN_DIR environment "
+            f"variable is set and {description} path '{path}' was not "
+            f"found via the VIRTUAL_ENV fallback. Required for relative "
+            f"{description} path."
+        )
 
     def _normalize_from_args(self, args: dict) -> dict[str, Any]:
         """Convert trigger args (all strings) to the internal normalized format."""

--- a/influxdata/schema_validator/manifest.toml
+++ b/influxdata/schema_validator/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "schema_validator"
-version = "0.1.0"
+version = "0.2.0"
 description = "Validates incoming line protocol data against a JSON schema."
 triggers = ["process_writes"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/schema_validator/schema_validator.py
+++ b/influxdata/schema_validator/schema_validator.py
@@ -110,19 +110,39 @@ def load_schema(influxdb3_local, schema_file_path: str, task_id: str) -> dict | 
     if cached is not None:
         return cached
 
-    plugin_dir_var = os.getenv("PLUGIN_DIR", None)
-    if not plugin_dir_var:
-        influxdb3_local.error(f"[{task_id}] PLUGIN_DIR environment variable is not set")
-        return None
-
     if not schema_file_path.endswith(".json"):
         influxdb3_local.error(
             f"[{task_id}] Invalid schema file format: expected a .json file"
         )
         return None
 
-    plugin_dir = Path(plugin_dir_var)
-    file_path = plugin_dir / schema_file_path
+    plugin_dir_var = os.getenv("PLUGIN_DIR", None)
+    if plugin_dir_var:
+        plugin_dir = Path(plugin_dir_var)
+        file_path = plugin_dir / schema_file_path
+    else:
+        # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+        #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+        #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+        candidates: list[str] = []
+        if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+            candidates.append(influxdb3_plugin_dir)
+        if virtual_env := os.environ.get("VIRTUAL_ENV"):
+            candidates.append(str(Path(virtual_env).parent))
+
+        resolved = None
+        for base in candidates:
+            candidate = Path(base) / schema_file_path
+            if candidate.exists():
+                resolved = candidate
+                break
+
+        if resolved is None:
+            candidates_str = ", ".join(candidates) if candidates else "none available"
+            influxdb3_local.error(f"[{task_id}] PLUGIN_DIR env var not set and schema file path '{schema_file_path}' was not found via fallbacks (tried: {candidates_str})")
+            return None
+
+        file_path = resolved
 
     try:
         with open(file_path, "r") as f:
@@ -459,10 +479,31 @@ def process_writes(influxdb3_local, table_batches: list, args: dict | None = Non
                 try:
                     plugin_dir_var = os.getenv("PLUGIN_DIR", None)
                     if not plugin_dir_var:
-                        influxdb3_local.error(f"[{task_id}] PLUGIN_DIR env var not set")
-                        return
-                    plugin_dir = Path(plugin_dir_var)
-                    file_path = plugin_dir / path
+                        # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                        #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                        #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                        candidates: list[str] = []
+                        if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                            candidates.append(influxdb3_plugin_dir)
+                        if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                            candidates.append(str(Path(virtual_env).parent))
+
+                        resolved = None
+                        for base in candidates:
+                            candidate = Path(base) / path
+                            if candidate.exists():
+                                resolved = candidate
+                                break
+
+                        if resolved is None:
+                            candidates_str = ", ".join(candidates) if candidates else "none available"
+                            influxdb3_local.error(f"[{task_id}] PLUGIN_DIR env var not set and config file path '{path}' was not found via fallbacks (tried: {candidates_str})")
+                            return
+
+                        file_path = resolved
+                    else:
+                        plugin_dir = Path(plugin_dir_var)
+                        file_path = plugin_dir / path
                     influxdb3_local.info(f"[{task_id}] Reading trigger config from {file_path}")
                     with open(file_path, "rb") as f:
                         args = tomllib.load(f)

--- a/influxdata/state_change/manifest.toml
+++ b/influxdata/state_change/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "state_change"
-version = "1.0.0"
+version = "1.1.0"
 description = "Provides field change and threshold monitoring capabilities through scheduler and data writes plugins. Detects changes in field values or threshold conditions with customizable notification templates."
 triggers = ["process_writes", "process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/state_change/state_change_check_plugin.py
+++ b/influxdata/state_change/state_change_check_plugin.py
@@ -823,13 +823,33 @@ def process_writes(influxdb3_local, table_batches: list, args: dict | None = Non
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)
@@ -1243,13 +1263,33 @@ def process_scheduled_call(
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/stateless_adtk_detector/adtk_anomaly_detection_plugin.py
+++ b/influxdata/stateless_adtk_detector/adtk_anomaly_detection_plugin.py
@@ -627,13 +627,33 @@ def process_scheduled_call(
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/stateless_adtk_detector/manifest.toml
+++ b/influxdata/stateless_adtk_detector/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "stateless_adtk_detector"
-version = "1.0.0"
+version = "1.1.0"
 description = "Provides anomaly detection capabilities for time series data using the ADTK library. Supports multiple stateless detectors with consensus-based detection and customizable notification messages."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/system_metrics/manifest.toml
+++ b/influxdata/system_metrics/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "system_metrics"
-version = "1.0.0"
+version = "1.1.0"
 description = "Collects system-level metrics (CPU, memory, disk, and network) using psutil and writes them to InfluxDB. Designed to run on a schedule and provide observability into host-level performance."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/system_metrics/system_metrics.py
+++ b/influxdata/system_metrics/system_metrics.py
@@ -52,6 +52,7 @@ import psutil
 import uuid
 import os
 import tomllib
+from pathlib import Path
 
 def collect_cpu_metrics(influxdb3_local, hostname, task_id):
     # Get CPU frequencies
@@ -251,15 +252,44 @@ def process_scheduled_call(influxdb3_local, time, args=None):
     try:
         # Load configuration from TOML file if provided
         if args and 'config_file_path' in args:
-            plugin_dir = os.environ.get('PLUGIN_DIR')
-            if plugin_dir:
-                config_file = args['config_file_path']
-                if not config_file.endswith('.toml'):
-                    influxdb3_local.error(
-                        f"[{task_id}] Invalid config file format: expected a .toml file"
-                    )
-                else:
+            config_file = args['config_file_path']
+            if not config_file.endswith('.toml'):
+                influxdb3_local.error(
+                    f"[{task_id}] Invalid config file format: expected a .toml file"
+                )
+            else:
+                plugin_dir = os.environ.get('PLUGIN_DIR')
+                if plugin_dir:
                     config_path = os.path.join(plugin_dir, config_file)
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates = []
+                    if influxdb3_plugin_dir := os.environ.get('INFLUXDB3_PLUGIN_DIR'):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get('VIRTUAL_ENV'):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = os.path.join(base, config_file)
+                        if os.path.exists(candidate):
+                            resolved = candidate
+                            break
+
+                    if resolved:
+                        config_path = resolved
+                    else:
+                        # Match original behavior: continue with inline args
+                        # when the config file cannot be resolved.
+                        config_path = None
+                        candidate_str = ', '.join(candidates) if candidates else 'none available'
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path '{config_file}' was not found via fallbacks (tried: {candidate_str})"
+                        )
+
+                if config_path:
                     try:
                         with open(config_path, 'rb') as f:
                             config = tomllib.load(f)

--- a/influxdata/threshold_deadman_checks/manifest.toml
+++ b/influxdata/threshold_deadman_checks/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "threshold_deadman_checks"
-version = "1.0.0"
+version = "1.1.0"
 description = "Provides comprehensive monitoring capabilities including deadman alerts and aggregation-based threshold checks. Supports both scheduler and data write triggers with multi-channel notifications."
 triggers = ["process_writes", "process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/threshold_deadman_checks/threshold_deadman_checks_plugin.py
+++ b/influxdata/threshold_deadman_checks/threshold_deadman_checks_plugin.py
@@ -644,13 +644,33 @@ def process_writes(influxdb3_local, table_batches: list, args: dict):
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)
@@ -1189,13 +1209,33 @@ def process_scheduled_call(influxdb3_local, call_time: datetime, args: dict):
                 return
             try:
                 plugin_dir_var: str | None = os.getenv("PLUGIN_DIR", None)
-                if not plugin_dir_var:
-                    influxdb3_local.error(
-                        f"[{task_id}] Failed to get PLUGIN_DIR env var"
-                    )
-                    return
-                plugin_dir: Path = Path(plugin_dir_var)
-                file_path = plugin_dir / path
+                if plugin_dir_var:
+                    file_path = Path(plugin_dir_var) / path
+                else:
+                    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+                    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+                    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+                    candidates: list[str] = []
+                    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                        candidates.append(influxdb3_plugin_dir)
+                    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                        candidates.append(str(Path(virtual_env).parent))
+
+                    resolved = None
+                    for base in candidates:
+                        candidate = Path(base) / path
+                        if candidate.exists():
+                            resolved = candidate
+                            break
+
+                    if resolved is None:
+                        candidates_str = ", ".join(candidates) if candidates else "none available"
+                        influxdb3_local.error(
+                            f"[{task_id}] PLUGIN_DIR env var not set and config file path "
+                            f"'{path}' was not found via fallbacks (tried: {candidates_str})"
+                        )
+                        return
+                    file_path = resolved
                 influxdb3_local.info(f"[{task_id}] Reading config file {file_path}")
                 with open(file_path, "rb") as f:
                     args = tomllib.load(f)

--- a/influxdata/valuecounter/manifest.toml
+++ b/influxdata/valuecounter/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "valuecounter"
-version = "0.1.0"
+version = "0.2.0"
 description = "Counts unique field values from data-write or scheduled inputs and writes rollup measurements with per-value counts."
 triggers = ["process_writes", "process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/valuecounter/valuecounter.py
+++ b/influxdata/valuecounter/valuecounter.py
@@ -75,6 +75,7 @@ import time
 import tomllib
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 
 # At server runtime LineBuilder is injected as a builtin. In test environments
 # pytest patches this module-level name to a vendored copy. The reference in
@@ -225,7 +226,27 @@ def _resolve_config(args, plugin_dir, mode):
         raise ValueError("set either config_file_path or inline args, not both")
 
     if cfp is not None:
-        path = os.path.join(plugin_dir, cfp)
+        if plugin_dir is not None:
+            path = os.path.join(plugin_dir, cfp)
+        else:
+            # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+            #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+            #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+            candidates = []
+            if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+                candidates.append(influxdb3_plugin_dir)
+            if virtual_env := os.environ.get("VIRTUAL_ENV"):
+                candidates.append(str(Path(virtual_env).parent))
+
+            path = None
+            for base in candidates:
+                candidate = os.path.join(base, cfp)
+                if os.path.exists(candidate):
+                    path = candidate
+                    break
+            if path is None:
+                # Original default: resolve against the current directory.
+                path = os.path.join(".", cfp)
         cfg = _load_toml_config(path, mode=mode)
     else:
         cfg = _parse_inline_args(args, mode=mode)
@@ -344,7 +365,7 @@ def process_scheduled_call(influxdb3_local, call_time, args=None):
     # call_time arrives as a PyDateTime per system_py.rs:847,867
     call_time_ns = int(call_time.timestamp()) * 1_000_000_000 + call_time.microsecond * 1000
 
-    cfg = _resolve_config(args or {}, os.environ.get("PLUGIN_DIR", "."), mode="scheduled")
+    cfg = _resolve_config(args or {}, os.environ.get("PLUGIN_DIR"), mode="scheduled")
 
     anchor_key = f"vc:scheduled:last_call_ns:{cfg.table}"
     last_call_ns = influxdb3_local.cache.get(anchor_key)
@@ -436,7 +457,7 @@ def process_writes(influxdb3_local, table_batches, args=None):
     task_id = uuid.uuid4().hex[:8]
     now_ns = time.time_ns()
 
-    cfg = _resolve_config(args or {}, os.environ.get("PLUGIN_DIR", "."), mode="wal")
+    cfg = _resolve_config(args or {}, os.environ.get("PLUGIN_DIR"), mode="wal")
 
     period_ns = cfg.period_seconds * 1_000_000_000
     ttl = 2 * cfg.period_seconds


### PR DESCRIPTION
## Summary

Closes #99.

All 21 plugins that support TOML configuration resolve a relative `config_file_path` against the `PLUGIN_DIR` environment variable — which the InfluxDB 3 server never sets. This breaks the API-only workflow of uploading a config via `POST /api/v3/plugins/files` and referencing it by the same relative path in `trigger_arguments`.

This PR extends the resolution in all 21 plugins with two fallbacks consulted **only when `PLUGIN_DIR` is unset**:

1. `PLUGIN_DIR` — unchanged, keeps highest precedence (existing behavior).
2. `INFLUXDB3_PLUGIN_DIR` — the documented env-var form of `--plugin-dir`; visible to plugin code when the operator configures the server that way (e.g. the official Docker image).
3. `Path(os.environ["VIRTUAL_ENV"]).parent` — the processing engine activates a venv at startup whose default location is `<plugin-dir>/.venv`, so its parent is the plugin directory.

Fallback candidates are accepted only if the resolved file actually exists; otherwise resolution fails with an error listing every location tried.

One commit per plugin (21 commits), identical treatment adapted to each plugin's existing style (`_resolve_path` helpers in the subscriber/OPC UA plugins, inline blocks elsewhere). Two notes on the recently merged plugins:

- `sagemaker` already consulted `INFLUXDB3_PLUGIN_DIR` alongside `PLUGIN_DIR`; that precedence is kept and only the `VIRTUAL_ENV` fallback is appended.
- `valuecounter` previously defaulted to the current directory when `PLUGIN_DIR` was unset; that default is preserved as the final fallback, and the `_resolve_config` signature used by its unit tests is unchanged (82/82 tests pass).

## Why this is non-breaking

- Absolute paths: unchanged.
- `PLUGIN_DIR` set: unchanged result; fallbacks never consulted — verified by pointing `PLUGIN_DIR` at a different directory than `--plugin-dir` and observing identical resolution before/after.
- `PLUGIN_DIR` unset: previously always an error; the fallbacks only turn some of those errors into successes. The remaining failure case gains a clearer message.
- `system_metrics` keeps its original continue-without-config behavior when resolution fails (it never aborted the run, and still doesn't).

## Verification

- `python3 -m py_compile` clean on all 21 modified files; valuecounter's unit suite passes (82/82).
- Live end-to-end test against InfluxDB 3 Core 3.9.3 with the modified `downsampler`, **no `PLUGIN_DIR` exported**: uploaded `configs/downsampler.toml` via `POST /api/v3/plugins/files`, created a trigger with `config_file_path=configs/downsampler.toml`, and observed `Reading config file` / `Config file loaded successfully` in the server log. The same setup previously failed with `Failed to get PLUGIN_DIR env var`.
- Resolution-precedence scenarios (flag-only, `PLUGIN_DIR` exported, `INFLUXDB3_PLUGIN_DIR`-configured server) verified live with a side-by-side probe plugin; details and observed output in #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
