### PR TITLE
make stock_plugin run without configuration via default portfolio

### DIFF
--- a/influxdata/stock_plugin/README.md
+++ b/influxdata/stock_plugin/README.md
@@ -20,28 +20,28 @@ This plugin includes a JSON metadata schema in its docstring that defines the su
 
 ### Optional parameters
 
-| Parameter     | Type   | Default                | Description                                                                                                                                              |
-|---------------|--------|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `database`    | string | `stocks`               | Target database for writes. Overrides the TOML `database` key if both are set.                                                                           |
-| `portfolio`   | string | none                   | Inline holdings: pipe-separated `SYMBOL:QUANTITY[:PORTFOLIO_NAME]` entries (e.g. `AAPL:10:401k\|MSFT:5:401k\|GOOG:2.5:brokerage`). Portfolio defaults to `main`. |
-| `categories`  | string | none                   | Inline category map: pipe-separated `PORTFOLIO:CATEGORY` entries (e.g. `401k:Retirement\|brokerage:Investment`).                                          |
-| `config_path` | string | `stock_plugin.toml`    | Path to the TOML config file, relative to the InfluxDB plugin directory (or absolute).                                                                   |
+| Parameter     | Type   | Default                  | Description                                                                                                                                                                                                                                 |
+|---------------|--------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `database`    | string | `stocks`                 | Target database for writes. Overrides the TOML `database` key if both are set.                                                                                                                                                              |
+| `portfolio`   | string | `AAPL:1\|MSFT:1\|GOOG:1` | Inline holdings: pipe-separated `SYMBOL:QUANTITY[:PORTFOLIO_NAME]` entries (e.g. `AAPL:10:401k\|MSFT:5:401k\|GOOG:2.5:brokerage`). Portfolio defaults to `main`. When omitted and no TOML config is found, falls back to the default shown. |
+| `categories`  | string | none                     | Inline category map: pipe-separated `PORTFOLIO:CATEGORY` entries (e.g. `401k:Retirement\|brokerage:Investment`).                                                                                                                            |
+| `config_path` | string | `stock_plugin.toml`      | Path to the TOML config file, relative to the InfluxDB plugin directory (or absolute).                                                                                                                                                      |
 
-*One of `portfolio` or a TOML file containing at least one `[holdings.<name>]` table is required.*
+*If neither `portfolio` nor a TOML file with `[holdings.<name>]` is provided, the plugin runs with the default holdings `AAPL:1|MSFT:1|GOOG:1` in the `main` portfolio.*
 
 ### TOML configuration
 
 The TOML file is the recommended way to configure anything more than a handful of holdings. The plugin reads it from `config_path` (default: `<plugin-dir>/stock_plugin.toml`).
 
-| Key                         | Type    | Default     | Description                                                                                                                                                          |
-|-----------------------------|---------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `database`                  | string  | `stocks`            | Target database for writes.                                                                                                                                          |
-| `write_during_closed_hours` | boolean | `true`              | When `false`, stocks/ETFs are skipped outside the configured exchange's regular session (the calendar handles holidays and early closes). Mutual funds always follow their own daily check schedule. |
-| `mutual_fund_check_time`    | string  | `"18:00"`           | Time of day in `market_timezone` after which the plugin fetches mutual fund NAV. Mutual funds are fetched at most once per local calendar day, at the first tick at or after this time. Bootstrap exception: a mutual fund with no cached asset type is fetched on its first tick regardless of time. |
-| `market_calendar`           | string  | `"NYSE"`            | Exchange calendar used for the market-hours check. Any name accepted by [pandas_market_calendars](https://pandas-market-calendars.readthedocs.io/) (e.g. `NYSE`, `LSE`, `TSX`, `JPX`, `XETR`, `ASX`, `HKEX`). |
-| `market_timezone`           | string  | `"America/New_York"`| IANA timezone for the exchange's local time. Used for `mutual_fund_check_time` comparisons and for resolving the "today" date the calendar consults.                |
-| `[portfolio_categories]`    | table   | empty               | Maps portfolio name to category name. Portfolios not listed are uncategorized (omitted from `category_totals`).                                                      |
-| `[holdings.<portfolio>]`    | table   | required            | Holdings for each portfolio. Each entry is `SYMBOL = quantity`. Fractional quantities supported. Quote symbols containing dots, for example `"VOD.L" = 10`. Duplicate same-symbol entries in one portfolio are aggregated. The portfolio name `_total` is reserved. |
+| Key                         | Type    | Default              | Description                                                                                                                                                                                                                                                                                                                                                       |
+|-----------------------------|---------|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `database`                  | string  | `stocks`             | Target database for writes.                                                                                                                                                                                                                                                                                                                                       |
+| `write_during_closed_hours` | boolean | `true`               | When `false`, stocks/ETFs are skipped outside the configured exchange's regular session (the calendar handles holidays and early closes). Mutual funds always follow their own daily check schedule.                                                                                                                                                              |
+| `mutual_fund_check_time`    | string  | `"18:00"`            | Time of day in `market_timezone` after which the plugin fetches mutual fund NAV. Mutual funds are fetched at most once per local calendar day, at the first tick at or after this time. Bootstrap exception: a mutual fund with no cached asset type is fetched on its first tick regardless of time.                                                             |
+| `market_calendar`           | string  | `"NYSE"`             | Exchange calendar used for the market-hours check. Any name accepted by [pandas_market_calendars](https://pandas-market-calendars.readthedocs.io/) (e.g. `NYSE`, `LSE`, `TSX`, `JPX`, `XETR`, `ASX`, `HKEX`).                                                                                                                                                     |
+| `market_timezone`           | string  | `"America/New_York"` | IANA timezone for the exchange's local time. Used for `mutual_fund_check_time` comparisons and for resolving the "today" date the calendar consults.                                                                                                                                                                                                              |
+| `[portfolio_categories]`    | table   | empty                | Maps portfolio name to category name. Portfolios not listed are uncategorized (omitted from `category_totals`).                                                                                                                                                                                                                                                   |
+| `[holdings.<portfolio>]`    | table   | default holdings     | Holdings for each portfolio. Each entry is `SYMBOL = quantity`. Fractional quantities supported. Quote symbols containing dots, for example `"VOD.L" = 10`. Duplicate same-symbol entries in one portfolio are aggregated. The portfolio name `_total` is reserved. When no `[holdings.*]` section is present, the plugin falls back to `AAPL:1\|MSFT:1\|GOOG:1`. |
 
 The trigger spec is the source of truth for cadence. For example, `--trigger-spec "every:15m"` runs the plugin every 15 minutes.
 
@@ -229,9 +229,7 @@ Cache is cleared on server restart. The plugin self-bootstraps: any symbol with 
 
 #### Issue: No holdings are configured
 
-**Solution:** Provide either `portfolio` trigger arguments or a TOML file with at least one `[holdings.<portfolio>]` table.
-
-The plugin requires at least one holding before it can write portfolio rows. If you use a TOML file, confirm that `config_path` points to the file in the InfluxDB 3 plugin directory.
+**Solution:** With no `portfolio` argument and no TOML file, the plugin uses the default holdings `AAPL:1|MSFT:1|GOOG:1`. To track your own holdings, provide `portfolio` trigger arguments or a TOML file with at least one `[holdings.<portfolio>]` table. If you use a TOML file, confirm that `config_path` points to the file in the InfluxDB 3 plugin directory.
 
 #### Issue: Market-hours checks skip expected writes
 

--- a/influxdata/stock_plugin/manifest.toml
+++ b/influxdata/stock_plugin/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "stock_plugin"
-version = "0.1.0"
+version = "0.2.0"
 description = "Tracks stock, ETF, and mutual fund portfolio values from Yahoo Finance with market-hours gating and rollups."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/stock_plugin/stock_plugin.py
+++ b/influxdata/stock_plugin/stock_plugin.py
@@ -11,7 +11,7 @@
         {
             "name": "portfolio",
             "example": "AAPL:10:401k|MSFT:5:401k|GOOG:2.5:brokerage",
-            "description": "Inline holdings as pipe-separated SYMBOL:QUANTITY[:PORTFOLIO_NAME] entries. Required unless config_path points to a TOML file with holdings.",
+            "description": "Inline holdings as pipe-separated SYMBOL:QUANTITY[:PORTFOLIO_NAME] entries. Optional: when omitted and no TOML config is found, defaults to AAPL:1|MSFT:1|GOOG:1.",
             "required": false
         },
         {
@@ -182,6 +182,10 @@ class ResolvedConfig:
     market_timezone: str = "America/New_York"
 
 
+# Default holdings
+DEFAULT_PORTFOLIO = "AAPL:1|MSFT:1|GOOG:1"
+
+
 def parse_inline_portfolio(value: str) -> dict[str, list[Holding]]:
     """Parse the inline `portfolio=` trigger argument.
 
@@ -328,19 +332,23 @@ def load_toml_config(path: Path) -> tuple[dict, dict[str, list[Holding]]]:
         [holdings.brokerage]
         GOOG = 2.5
 
+    Holdings may be empty (no [holdings.*] sections); the caller decides
+    how to handle that (e.g. fall back to a default portfolio).
+
     Raises:
         FileNotFoundError: path does not exist
         tomllib.TOMLDecodeError: file is not valid TOML
-        ValueError: no usable [holdings.<portfolio>] sections
+        ValueError: holdings is not a table, or a holding has an invalid quantity
     """
     if not path.exists():
         raise FileNotFoundError(f"TOML config not found: {path}")
     with open(path, "rb") as f:
         data = tomllib.load(f)
     holdings_section = data.get("holdings", {})
-    if not isinstance(holdings_section, dict) or not holdings_section:
+    if not isinstance(holdings_section, dict):
         raise ValueError(
-            f"TOML config at {path} has no [holdings.<portfolio>] sections"
+            f"[holdings] must be a table of portfolios; "
+            f"got {type(holdings_section).__name__}"
         )
     result: dict[str, list[Holding]] = {}
     for portfolio_name, mapping in holdings_section.items():
@@ -371,10 +379,6 @@ def load_toml_config(path: Path) -> tuple[dict, dict[str, list[Holding]]]:
                     portfolio=portfolio_name,
                 )
             )
-    if not result:
-        raise ValueError(
-            f"TOML config at {path} has empty [holdings.<portfolio>] sections"
-        )
     return data, result
 
 
@@ -411,7 +415,7 @@ def resolve_config(
     """Resolve final config from trigger args + TOML.
 
     Precedence:
-      Holdings: inline `portfolio=` arg > TOML [holdings.*] (one or the other)
+      Holdings: inline `portfolio=` arg > TOML [holdings.*] > DEFAULT_PORTFOLIO
       Database: `database=` arg > TOML `database` > default "stocks"
       Config path: `config_path=` arg > default_toml_path. Relative paths
       resolve from INFLUXDB3_PLUGIN_DIR, PLUGIN_DIR, VIRTUAL_ENV's parent,
@@ -421,26 +425,30 @@ def resolve_config(
     market_calendar, market_timezone) come only from TOML — there is no
     inline-arg override for them. Defaults apply when the key is absent.
 
-    Raises ValueError if neither inline holdings nor a usable TOML file is
-    found, or if any TOML scalar has an invalid value.
+    When no inline holdings and no TOML file are found, falls back to
+    DEFAULT_PORTFOLIO so the plugin runs without configuration.
+
+    Raises ValueError if config_path is set but the file is missing, or if
+    any TOML scalar has an invalid value.
     """
     inline_portfolio = args.get("portfolio")
+    explicit_config_path = bool(args.get("config_path"))
     config_path = resolve_config_path(
         args.get("config_path") or str(default_toml_path),
         default_toml_path,
     )
 
     toml_data: dict = {}
+    holdings: dict[str, list[Holding]] = {}
     if inline_portfolio:
         holdings = parse_inline_portfolio(inline_portfolio)
-    else:
-        if not config_path.exists():
-            raise ValueError(
-                f"No 'portfolio' trigger arg provided and no TOML config "
-                f"at {config_path}. Either pass --trigger-arguments "
-                f"'portfolio=...' or create the TOML file."
-            )
+    elif config_path.exists():
         toml_data, holdings = load_toml_config(config_path)
+    elif explicit_config_path:
+        raise ValueError("config_path was set but no TOML config found.")
+
+    if not holdings:
+        holdings = parse_inline_portfolio(DEFAULT_PORTFOLIO)
 
     if "_total" in holdings:
         raise ValueError(

--- a/influxdata/stock_plugin/stock_plugin.toml.example
+++ b/influxdata/stock_plugin/stock_plugin.toml.example
@@ -35,7 +35,9 @@ market_timezone = "America/New_York"
 "401k" = "Retirement"
 brokerage = "Investment"
 
-# Holdings, grouped by portfolio name.
+# Holdings, grouped by portfolio name. Optional: if no [holdings.<portfolio>]
+# section is present, the plugin falls back to the default portfolio
+# AAPL:1|MSFT:1|GOOG:1.
 # Each [holdings.<portfolio_name>] table is a {symbol = quantity} mapping.
 # Fractional quantities are supported. Quote ticker symbols that contain
 # dots; unquoted dots are TOML nested-key syntax, not literal symbol text.


### PR DESCRIPTION
Make the stock plugin run without configuration using the default portfolio so it can be used on the Live Sample Data page in the UI