### PR TITLE
add Avro/JSON Schema/Protobuf formats with Schema Registry support

### DIFF
--- a/influxdata/kafka_subscriber/README.md
+++ b/influxdata/kafka_subscriber/README.md
@@ -8,7 +8,7 @@
 
 The Kafka Subscriber Plugin enables real-time ingestion of Kafka messages into InfluxDB 3. Subscribe to Kafka topics and automatically transform messages into time-series data with support for JSON, Line Protocol, and custom text formats. The plugin uses consumer groups for reliable message delivery and provides flexible offset commit policies for different use cases. The consumer is reused across scheduled invocations to avoid a consumer-group rebalance every cycle, and it optionally supports a dead-letter queue topic for failed messages and id-based deduplication for messages without their own timestamp.
 
-**Important:** Protobuf and Avro formats are NOT supported as they require Schema Registry integration. For these formats, consider using an external deserialization layer before writing to Kafka in a supported format.
+**Binary formats:** `avro`, `jsonschema`, and `protobuf` (Confluent wire format) are decoded via Confluent Schema Registry. `avro` can also be decoded as raw schemaless Avro with a local `.avsc` schema, and `protobuf` with a local `.proto` schema. See [Binary formats](#binary-formats).
 
 ## Configuration
 
@@ -22,13 +22,13 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 In TOML configuration, `bootstrap_servers`, `topics`, and `group_id` are placed under the `[kafka]` section; `table_name` and `table_name_field` are placed under `[mapping.json]` or `[mapping.text]` section.
 
-| Parameter           | Type   | Default                   | Description                                                                                                               |
-|---------------------|--------|---------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `bootstrap_servers` | string | required                  | Space-separated list of Kafka broker addresses (e.g., "kafka1:9092 kafka2:9092")                                          |
-| `topics`            | string | required                  | Space-separated list of topics (e.g., "sensor_data metrics")                                                              |
-| `group_id`          | string | required                  | Kafka consumer group ID (must be unique per consumer group)                                                               |
-| `table_name`        | string | required (json/text only) | InfluxDB measurement name for storing data. Not required for `lineprotocol` format or when `table_name_field` is set.     |
-| `table_name_field`  | string | none                      | JSON field name or regex pattern to extract table name dynamically from each message. Alternative to static `table_name`. |
+| Parameter           | Type   | Default                   | Description                                                                                                                   |
+|---------------------|--------|---------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `bootstrap_servers` | string | required                  | Space-separated list of Kafka broker addresses (e.g., "kafka1:9092 kafka2:9092")                                              |
+| `topics`            | string | required                  | Space-separated list of topics (e.g., "sensor_data metrics")                                                                  |
+| `group_id`          | string | required                  | Kafka consumer group ID (must be unique per consumer group)                                                                   |
+| `table_name`        | string | conditional               | InfluxDB measurement name for storing data. Required for all formats except `lineprotocol`, unless `table_name_field` is set. |
+| `table_name_field`  | string | none                      | JSON field name or regex pattern to extract table name dynamically from each message. Alternative to static `table_name`.     |
 
 ### Connection parameters
 
@@ -147,18 +147,21 @@ In TOML configuration, `dedup_window` is placed under the `[kafka]` section; `de
 
 In TOML configuration, `format` is placed under the `[kafka]` section; `timestamp_field` is placed under `[mapping.json]` or `[mapping.text]` section.
 
-| Parameter         | Type   | Default | Description                                                    |
-|-------------------|--------|---------|----------------------------------------------------------------|
-| `format`          | string | "json"  | Message format: json, lineprotocol, or text                    |
-| `timestamp_field` | string | none    | Field containing timestamp (format depends on message format)  |
+| Parameter         | Type   | Default | Description                                                          |
+|-------------------|--------|---------|----------------------------------------------------------------------|
+| `format`          | string | "json"  | Message format: json, lineprotocol, text, avro, jsonschema, protobuf |
+| `timestamp_field` | string | none    | Field containing timestamp (format depends on message format)        |
 
 **Supported formats:**
 
-| Format         | Description                                      |
-|----------------|--------------------------------------------------|
-| `json`         | JSON with JSONPath field mapping                 |
-| `lineprotocol` | InfluxDB Line Protocol passthrough               |
-| `text`         | Plain text with regex-based parsing              |
+| Format         | Description                                                            |
+|----------------|------------------------------------------------------------------------|
+| `json`         | JSON with JSONPath field mapping                                       |
+| `lineprotocol` | InfluxDB Line Protocol passthrough                                     |
+| `text`         | Plain text with regex-based parsing                                    |
+| `avro`         | Avro via Confluent Schema Registry (JSONPath mapping)                  |
+| `jsonschema`   | JSON Schema via Confluent Schema Registry (JSONPath)                   |
+| `protobuf`     | Protobuf (Confluent wire format) via Schema Registry or a local .proto |
 
 **Format-specific timestamp_field syntax:**
 
@@ -172,6 +175,10 @@ In TOML configuration, `format` is placed under the `[kafka]` section; `timestam
 - `ms` - milliseconds (Unix timestamp)
 - `s` - seconds (Unix timestamp)
 - `datetime` - ISO 8601 string (e.g., "2021-12-01T12:00:00Z")
+
+For `avro` and `jsonschema`, a field decoded as a native `datetime`/`date`
+(Avro/JSON Schema logical type) is converted to a timestamp automatically,
+regardless of the configured format specifier.
 
 ### JSON format parameters
 
@@ -195,6 +202,99 @@ In TOML configuration, `tags` are placed under `[mapping.text.tags]` section and
 | `tags`    | string | none      | Space-separated tag patterns. Format: "name=regex_pattern"        |
 | `fields`  | string | required  | Space-separated field patterns. Format: "name:type=regex_pattern" |
 
+### Binary formats
+
+The decoded record is a dict (or a top-level list, expanded into one record per
+element) for all binary formats, so field/tag/timestamp mapping uses the same
+JSONPath syntax as the JSON format, under `[mapping.avro]`,
+`[mapping.jsonschema]`, or `[mapping.protobuf]`.
+
+Per-message decode failures (schema id not found, malformed payload) are handled
+like parse failures: the message is logged to `kafka_exceptions`, sent to
+`dlq_topic` if configured, or replayed otherwise. Binary payloads are forwarded
+to the DLQ as the original raw bytes.
+
+An unreachable or misconfigured Schema Registry is caught when the decoder is
+first built: the cycle is aborted before any message is polled or committed, so
+nothing is lost, and the run retries on the next schedule.
+
+#### Avro / JSON Schema (Schema Registry)
+
+Set `format` to `avro` or `jsonschema` to consume binary messages in the
+Confluent wire format (magic byte + 4-byte schema id + payload). The schema is
+fetched from the Schema Registry by the id embedded in each message — no local
+schema files are needed.
+
+The parameter names are identical in CLI/API arguments and TOML. In TOML they
+are placed under the `[kafka.schema_registry]` section.
+
+| Parameter                              | Type   | Default  | Description                                                                                                 |
+|----------------------------------------|--------|----------|-------------------------------------------------------------------------------------------------------------|
+| `schema_registry_url`                  | string | required | Schema Registry URL. Required for `avro` / `jsonschema`, and for `protobuf` without `protobuf_schema_file`. |
+| `schema_registry_username`             | string | none     | Basic-auth username (or API key for Confluent Cloud).                                                       |
+| `schema_registry_password`             | string | none     | Basic-auth password (or API secret). Used with username.                                                    |
+| `schema_registry_ca_cert`              | string | none     | CA certificate for TLS to the registry.                                                                     |
+| `schema_registry_client_cert`          | string | none     | Client certificate for mutual TLS to the registry.                                                          |
+| `schema_registry_client_key`           | string | none     | Client private key for mutual TLS. Requires client cert.                                                    |
+| `schema_registry_client_key_password`  | string | none     | Password for an encrypted client private key.                                                               |
+
+> **Note:** `avro` and `jsonschema` require the extra packages `httpx`,
+> `fastavro`, and `jsonschema`.
+
+#### Avro (local .avsc schema, schemaless)
+
+Set `format` to `avro` and `avro_schema_file` to a local `.avsc` schema to
+consume Avro messages produced **without** a Schema Registry — raw schemaless
+encoding with no Confluent wire header. The whole message value is the Avro body
+and is decoded with the local schema; the Schema Registry is **not** contacted.
+
+The parameter name is identical in CLI/API arguments and TOML. In TOML it is
+placed under the `[kafka.avro]` section.
+
+| Parameter          | Type   | Default  | Description                                                                  |
+|--------------------|--------|----------|------------------------------------------------------------------------------|
+| `avro_schema_file` | string | required | Path to a local `.avsc`/`.json` schema (absolute or relative to PLUGIN_DIR). |
+
+> **Note:** requires the `fastavro` package. The schema is parsed once and
+> cached. Writer and reader schema are assumed identical (no schema evolution).
+
+#### Protobuf (local .proto or Schema Registry)
+
+Set `format` to `protobuf` to consume Protobuf messages in the Confluent wire
+format. The schema source is chosen implicitly, like `avro`:
+
+- **Local `.proto`** — set `protobuf_schema_file`. The wire framing is parsed
+  locally and the schema is read from the file; the Schema Registry is not
+  contacted.
+- **Schema Registry** — omit `protobuf_schema_file` and set `schema_registry_url`.
+  The `.proto` (and any referenced schemas) is fetched by the wire-frame schema
+  id, compiled with `protoc`, and cached per schema id. The `[kafka.schema_registry]`
+  section (url, auth, TLS) is shared with `avro`/`jsonschema`.
+
+The message index selects which message type to decode, or set
+`protobuf_message_type` to choose it explicitly. In registry mode the schema
+matches the producer's, so the message index is always correct and
+`protobuf_message_type` is usually unnecessary.
+
+The parameter names are identical in CLI/API arguments and TOML. In TOML they
+are placed under the `[kafka.protobuf]` section.
+
+| Parameter                | Type   | Default            | Description                                                                            |
+|--------------------------|--------|--------------------|----------------------------------------------------------------------------------------|
+| `protobuf_schema_file`   | string | conditional        | Path to a local `.proto` (absolute or relative to PLUGIN_DIR). Omit to use the registry. |
+| `protobuf_include_dir`   | string | schema file's dir  | Include directory for resolving `import` statements (local mode only).                 |
+| `protobuf_message_type`  | string | wire message index | Fully-qualified message name to decode (e.g. `sensors.SensorReading`).                 |
+
+> **Note:** `protobuf` requires `grpcio-tools` (bundles `protoc` to compile the
+> `.proto`); it is included in the plugin's dependencies and installed
+> automatically. The `.proto` is
+> compiled once and cached. `MessageToDict` semantics apply: proto3 scalar fields
+> equal to their default (`0`/`""`/`false`) are omitted from the record;
+> `int64`/`uint64` become strings; enums become their names; `bytes` become
+> base64 strings.
+
+See examples 11–14 in [kafka_config_example.toml](kafka_config_example.toml).
+
 ### TOML configuration
 
 | Parameter          | Type   | Default | Description                                     |
@@ -206,9 +306,9 @@ In TOML configuration, `tags` are placed under `[mapping.text.tags]` section and
 All file paths in the plugin (configuration file, TLS certificates) follow the same resolution logic:
 
 - **Absolute paths** (e.g., `/etc/kafka/config.toml`) are used as-is
-- **Relative paths** (e.g., `config.toml`, `certs/ca.crt`) are resolved from `PLUGIN_DIR` environment variable
+- **Relative paths** (e.g., `config.toml`, `certs/ca.crt`) are resolved against the plugin directory, taken from `PLUGIN_DIR`, then `INFLUXDB3_PLUGIN_DIR`, then the parent of `VIRTUAL_ENV`
 
-If a relative path is specified and `PLUGIN_DIR` is not set, the plugin will return an error.
+If a relative path is specified and none of these can be resolved, the plugin will return an error.
 
 #### Example TOML configuration
 
@@ -220,15 +320,20 @@ The plugin automatically creates the target measurement table on first write. Fi
 
 ### Message encoding requirements
 
-- **UTF-8 text only**: The plugin only processes UTF-8 encoded text messages. Binary messages (Protobuf, Avro) are not supported.
+- **Text formats** (`json`, `text`, `lineprotocol`): payloads must be UTF-8 encoded.
+- **Binary formats** (`avro`, `jsonschema`, `protobuf`): payloads are decoded from binary (see [Binary formats](#binary-formats)).
 - **Non-empty payloads**: Empty or whitespace-only messages are automatically skipped.
 
 ## Software Requirements
 
 - **InfluxDB 3 Core/Enterprise**: with the Processing Engine enabled
-- **Python packages**:
-  - `confluent-kafka` (High-performance Kafka client library based on librdkafka)
-  - `jsonpath-ng` (JSON path parsing for JSON format)
+- **Python packages** (all bundled in `manifest.toml` and installed automatically with the plugin):
+  - `confluent-kafka>=2.15.0` (Kafka client based on librdkafka) — all formats
+  - `jsonpath-ng` (JSONPath field mapping) — all formats
+  - `fastavro` — `avro` format (both Schema Registry and local `.avsc`)
+  - `httpx`, `authlib`, `cachetools` — any Schema Registry format (`avro` / `jsonschema` / registry-mode `protobuf`)
+  - `jsonschema` (library) — `jsonschema` message format only
+  - `protobuf`, `grpcio-tools` — `protobuf` format only
 
 ### Installation steps
 
@@ -361,7 +466,7 @@ Process batch messages containing arrays of JSON objects:
 **Array processing behavior:**
 - Each array element is processed independently as a separate data point
 - If one element fails to parse, the others continue processing (partial success)
-- Parse errors for individual elements are logged to `kafka_exceptions` table
+- Parse errors for individual elements are logged as warnings and the element is skipped (not written to `kafka_exceptions`)
 - Statistics count 1 Kafka message = 1 unit (regardless of array size)
 
 ### Line Protocol Format
@@ -413,6 +518,146 @@ humidity = ["hum:(\\d+)", "int"]
 
 ```
 location=warehouse_a,temp:22.5,hum:65,ts:1638360000000
+```
+
+### Avro Format (Schema Registry)
+
+Decode Avro messages in the Confluent wire format. The schema is resolved from
+the Schema Registry by the id embedded in each message; mapping uses JSONPath
+on the decoded record.
+
+#### TOML Configuration
+
+```toml
+[kafka]
+bootstrap_servers = ["kafka:9092"]
+topics = ["sensors.avro"]
+group_id = "influxdb3_avro"
+format = "avro"
+
+[kafka.schema_registry]
+schema_registry_url = "http://schema-registry:8081"
+# schema_registry_username = "sr_api_key"     # optional basic auth
+# schema_registry_password = "sr_api_secret"
+
+[mapping.avro]
+table_name = "sensor_data"
+timestamp_field = "$.timestamp:ms"
+
+[mapping.avro.tags]
+device_id = "$.device_id"
+
+[mapping.avro.fields]
+temperature = ["$.temperature", "float"]
+humidity = ["$.humidity", "float"]
+```
+
+### Avro Format (local .avsc schema, schemaless)
+
+Decode raw schemaless Avro (no Schema Registry, no wire header) with a local
+`.avsc` schema. Set `avro_schema_file` to switch `format = "avro"` to this mode.
+
+```toml
+[kafka]
+bootstrap_servers = ["kafka:9092"]
+topics = ["sensors.avro"]
+group_id = "influxdb3_avro_file"
+format = "avro"
+
+[kafka.avro]
+avro_schema_file = "schemas/sensor.avsc"
+
+[mapping.avro]
+table_name = "sensor_data"
+timestamp_field = "$.timestamp:ms"
+
+[mapping.avro.tags]
+device_id = "$.device_id"
+
+[mapping.avro.fields]
+temperature = ["$.temperature", "float"]
+humidity = ["$.humidity", "float"]
+```
+
+### JSON Schema Format (Schema Registry)
+
+Decode JSON-Schema messages in the Confluent wire format. Configuration mirrors
+the Avro example, using `format = "jsonschema"` and `[mapping.jsonschema]`.
+
+```toml
+[kafka]
+bootstrap_servers = ["kafka:9092"]
+topics = ["events.jsonschema"]
+group_id = "influxdb3_jsonschema"
+format = "jsonschema"
+
+[kafka.schema_registry]
+schema_registry_url = "http://schema-registry:8081"
+
+[mapping.jsonschema]
+table_name = "events"
+timestamp_field = "$.ts:ms"
+
+[mapping.jsonschema.fields]
+value = ["$.value", "float"]
+```
+
+### Protobuf Format (local .proto schema)
+
+Decode Protobuf messages in the Confluent wire format using a local `.proto`
+file. The Schema Registry is not contacted; the message type is selected by the
+wire message index, or set `protobuf_message_type` to choose it explicitly.
+
+```toml
+[kafka]
+bootstrap_servers = ["kafka:9092"]
+topics = ["sensors.protobuf"]
+group_id = "influxdb3_protobuf"
+format = "protobuf"
+
+[kafka.protobuf]
+protobuf_schema_file = "schemas/sensor.proto"
+# protobuf_include_dir = "schemas"               # optional, for .proto imports
+# protobuf_message_type = "sensors.SensorReading" # optional, defaults to wire message index
+
+[mapping.protobuf]
+table_name = "sensor_data"
+timestamp_field = "$.timestamp:ms"
+
+[mapping.protobuf.tags]
+device_id = "$.device_id"
+
+[mapping.protobuf.fields]
+temperature = ["$.temperature", "float"]
+humidity = ["$.humidity", "float"]
+```
+
+### Protobuf Format (Schema Registry)
+
+Omit `protobuf_schema_file` and set `schema_registry_url` to fetch and compile
+the `.proto` (and any referenced schemas) by the wire-frame schema id. The
+`[kafka.protobuf]` section can be omitted entirely.
+
+```toml
+[kafka]
+bootstrap_servers = ["kafka:9092"]
+topics = ["sensors.protobuf"]
+group_id = "influxdb3_protobuf_sr"
+format = "protobuf"
+
+[kafka.schema_registry]
+schema_registry_url = "http://schema-registry:8081"
+
+[mapping.protobuf]
+table_name = "sensor_data"
+timestamp_field = "$.timestamp:ms"
+
+[mapping.protobuf.tags]
+device_id = "$.device_id"
+
+[mapping.protobuf.fields]
+temperature = ["$.temperature", "float"]
+humidity = ["$.humidity", "float"]
 ```
 
 ## Statistics and Monitoring
@@ -468,7 +713,6 @@ Parse errors and message processing failures are logged to the `kafka_exceptions
 | `error_type` (tag)  | tag    | Type of error (e.g., JSONDecodeError)    |
 | `offset`            | int    | Message offset                           |
 | `error_message`     | string | Detailed error message                   |
-| `raw_message`       | string | Original message (truncated to 1KB)      |
 
 ### Checking for Errors
 

--- a/influxdata/kafka_subscriber/kafka_config_example.toml
+++ b/influxdata/kafka_subscriber/kafka_config_example.toml
@@ -13,8 +13,10 @@
 # - Absolute paths (e.g., /etc/kafka/ca.crt) are used as-is
 # - Relative paths (e.g., certs/ca.crt) are resolved from PLUGIN_DIR
 #
-# IMPORTANT: Protobuf and Avro formats are NOT supported as they require
-# Schema Registry integration. Use JSON, Line Protocol, or Text formats.
+# Binary formats: 'avro', 'jsonschema', and 'protobuf' (Confluent wire format)
+# are supported via Confluent Schema Registry (examples 11-13). 'protobuf' can
+# also be decoded with a local .proto schema, and 'avro' as raw schemaless Avro
+# with a local .avsc schema, without a registry (examples 13-14).
 # =============================================================================
 
 
@@ -389,3 +391,163 @@ online = ["$.online", "bool"]
 # # [mapping.text]
 # # dedup_id_field = "id=([\\w-]+)"
 # # dedup_id_name = "event_id"
+
+
+# #############################################################################
+# EXAMPLE 11: Avro Format via Confluent Schema Registry
+# #############################################################################
+# Use this configuration for Avro-encoded messages in the Confluent wire format
+# (magic byte + 4-byte schema id + payload). The schema is fetched from the
+# Schema Registry by id; no local schema files are needed.
+#
+# The decoded record is a dict, so the mapping uses the same JSONPath syntax as
+# the JSON format - just under [mapping.avro].
+# #############################################################################
+
+# [kafka]
+# bootstrap_servers = ["kafka:9092"]
+# topics = ["sensors.avro"]
+# group_id = "influxdb3_avro_consumer"
+# format = "avro"
+# offset_commit_policy = "on_success"
+# auto_offset_reset = "earliest"
+# security_protocol = "PLAINTEXT"
+
+# [kafka.schema_registry]
+# schema_registry_url = "http://schema-registry:8081"
+# # Basic auth (e.g. Confluent Cloud API key/secret):
+# # schema_registry_username = "sr_api_key"
+# # schema_registry_password = "sr_api_secret"
+# # TLS to the registry (paths absolute or relative to PLUGIN_DIR):
+# # schema_registry_ca_cert = "certs/sr_ca.crt"
+# # schema_registry_client_cert = "certs/sr_client.crt"   # mutual TLS
+# # schema_registry_client_key = "certs/sr_client.key"
+# # schema_registry_client_key_password = "sr_key_password"  # only if the client key is encrypted
+
+# [mapping.avro]
+# table_name = "sensor_data"
+# timestamp_field = "$.timestamp:ms"
+
+# [mapping.avro.tags]
+# device_id = "$.device_id"
+# location = "$.location"
+
+# [mapping.avro.fields]
+# temperature = ["$.temperature", "float"]
+# humidity = ["$.humidity", "float"]
+
+
+# #############################################################################
+# EXAMPLE 12: JSON Schema Format via Confluent Schema Registry
+# #############################################################################
+# Use this configuration for JSON-Schema-encoded messages in the Confluent wire
+# format. The payload is validated against the schema fetched from the registry
+# and decoded to a dict. Mapping uses JSONPath under [mapping.jsonschema].
+# #############################################################################
+
+# [kafka]
+# bootstrap_servers = ["kafka:9092"]
+# topics = ["events.jsonschema"]
+# group_id = "influxdb3_jsonschema_consumer"
+# format = "jsonschema"
+# offset_commit_policy = "on_success"
+# auto_offset_reset = "earliest"
+# security_protocol = "PLAINTEXT"
+
+# [kafka.schema_registry]
+# schema_registry_url = "http://schema-registry:8081"
+
+# [mapping.jsonschema]
+# table_name = "events"
+# timestamp_field = "$.ts:ms"
+
+# [mapping.jsonschema.tags]
+# host = "$.host"
+
+# [mapping.jsonschema.fields]
+# value = ["$.value", "float"]
+
+
+# #############################################################################
+# EXAMPLE 13: Protobuf Format (Confluent wire format)
+# #############################################################################
+# Use this configuration for Protobuf messages in the Confluent wire format
+# (magic byte + schema id + message index). The schema source is chosen
+# implicitly: set protobuf_schema_file for a LOCAL .proto (registry not
+# contacted), or omit it and set schema_registry_url to fetch and compile the
+# .proto (and any references) from the Schema Registry by the wire-frame schema
+# id. The message index selects the message type.
+#
+# The 'grpcio-tools' package (bundles protoc to compile the .proto) is included
+# in the plugin's dependencies and installed automatically.
+#
+# Note on MessageToDict semantics: proto3 scalar fields equal to their default
+# (0, "", false) are omitted from the decoded record; int64/uint64 fields become
+# strings; enums become their names; bytes become base64 strings.
+# #############################################################################
+
+# [kafka]
+# bootstrap_servers = ["kafka:9092"]
+# topics = ["sensors.protobuf"]
+# group_id = "influxdb3_protobuf_consumer"
+# format = "protobuf"
+# offset_commit_policy = "on_success"
+# auto_offset_reset = "earliest"
+# security_protocol = "PLAINTEXT"
+
+# Local .proto mode:
+# [kafka.protobuf]
+# protobuf_schema_file = "schemas/sensor.proto"   # path (absolute or relative to PLUGIN_DIR)
+# # protobuf_include_dir = "schemas"               # optional: include dir for .proto imports
+# # protobuf_message_type = "sensors.SensorReading" # optional: defaults to the wire message index
+
+# Schema Registry mode (alternative): omit protobuf_schema_file and set the URL.
+# The [kafka.protobuf] section can be omitted entirely.
+# [kafka.schema_registry]
+# schema_registry_url = "http://schema-registry:8081"
+
+# [mapping.protobuf]
+# table_name = "sensor_data"
+# timestamp_field = "$.timestamp:ms"
+
+# [mapping.protobuf.tags]
+# device_id = "$.device_id"
+
+# [mapping.protobuf.fields]
+# temperature = ["$.temperature", "float"]
+# humidity = ["$.humidity", "float"]
+
+
+# #############################################################################
+# EXAMPLE 14: Avro Format via Local Schema File (raw schemaless, no registry)
+# #############################################################################
+# Use this for Avro messages produced WITHOUT a Schema Registry (raw schemaless
+# encoding, no Confluent wire header). The whole message value is the Avro body
+# and is decoded with the local .avsc schema. Set avro_schema_file to switch the
+# 'avro' format to this mode; the Schema Registry is not contacted.
+#
+# The decoded record is a dict, so mapping uses JSONPath under [mapping.avro].
+# #############################################################################
+
+# [kafka]
+# bootstrap_servers = ["kafka:9092"]
+# topics = ["sensors.avro"]
+# group_id = "influxdb3_avro_file_consumer"
+# format = "avro"
+# offset_commit_policy = "on_success"
+# auto_offset_reset = "earliest"
+# security_protocol = "PLAINTEXT"
+
+# [kafka.avro]
+# avro_schema_file = "schemas/sensor.avsc"   # path (absolute or relative to PLUGIN_DIR)
+
+# [mapping.avro]
+# table_name = "sensor_data"
+# timestamp_field = "$.timestamp:ms"
+
+# [mapping.avro.tags]
+# device_id = "$.device_id"
+
+# [mapping.avro.fields]
+# temperature = ["$.temperature", "float"]
+# humidity = ["$.humidity", "float"]

--- a/influxdata/kafka_subscriber/kafka_subscriber.py
+++ b/influxdata/kafka_subscriber/kafka_subscriber.py
@@ -29,13 +29,79 @@
         {
             "name": "format",
             "example": "json",
-            "description": "Message format: 'json', 'lineprotocol', or 'text'. Default: 'json'. Note: Protobuf and Avro are not supported.",
+            "description": "Message format: 'json', 'lineprotocol', 'text', 'avro', 'jsonschema', or 'protobuf'. Default: 'json'. 'avro' decodes via Confluent Schema Registry (set schema_registry_url) or, if avro_schema_file is set, raw schemaless Avro with a local .avsc schema. 'jsonschema' decodes via Confluent Schema Registry. 'protobuf' decodes Confluent wire-format messages using a local .proto schema (set protobuf_schema_file) or via the Schema Registry (set schema_registry_url without protobuf_schema_file).",
+            "required": false
+        },
+        {
+            "name": "schema_registry_url",
+            "example": "https://schema-registry:8081",
+            "description": "Confluent Schema Registry URL. Required for 'avro', 'jsonschema' and 'protobuf'.",
+            "required": false
+        },
+        {
+            "name": "schema_registry_username",
+            "example": "sr_user",
+            "description": "Schema Registry basic-auth username (or API key for Confluent Cloud).",
+            "required": false
+        },
+        {
+            "name": "schema_registry_password",
+            "example": "sr_password",
+            "description": "Schema Registry basic-auth password (or API secret). Used with schema_registry_username.",
+            "required": false
+        },
+        {
+            "name": "schema_registry_ca_cert",
+            "example": "certs/sr_ca.crt",
+            "description": "Path to CA certificate for TLS to Schema Registry (absolute or relative to PLUGIN_DIR).",
+            "required": false
+        },
+        {
+            "name": "schema_registry_client_cert",
+            "example": "certs/sr_client.crt",
+            "description": "Path to client certificate for mutual TLS to Schema Registry.",
+            "required": false
+        },
+        {
+            "name": "schema_registry_client_key",
+            "example": "certs/sr_client.key",
+            "description": "Path to client private key for mutual TLS to Schema Registry. Requires schema_registry_client_cert.",
+            "required": false
+        },
+        {
+            "name": "schema_registry_client_key_password",
+            "example": "sr_key_password",
+            "description": "Password for an encrypted Schema Registry client private key.",
+            "required": false
+        },
+        {
+            "name": "avro_schema_file",
+            "example": "schemas/sensor.avsc",
+            "description": "Path to a local Avro schema file (.avsc/.json, absolute or relative to PLUGIN_DIR). When set with format 'avro', messages are decoded as raw schemaless Avro (no Confluent wire header) and the Schema Registry is not used.",
+            "required": false
+        },
+        {
+            "name": "protobuf_schema_file",
+            "example": "schemas/sensor.proto",
+            "description": "Path to a local .proto schema file (absolute or relative to PLUGIN_DIR). Used by the 'protobuf' format for local decoding; omit it to fetch the schema from the Schema Registry (set schema_registry_url instead).",
+            "required": false
+        },
+        {
+            "name": "protobuf_include_dir",
+            "example": "schemas",
+            "description": "Include directory for resolving 'import' statements in the .proto file. Defaults to the schema file's directory.",
+            "required": false
+        },
+        {
+            "name": "protobuf_message_type",
+            "example": "sensors.SensorReading",
+            "description": "Fully-qualified protobuf message name to decode. Optional; by default the message is selected via the Confluent wire-format message index.",
             "required": false
         },
         {
             "name": "table_name",
             "example": "sensor_data",
-            "description": "InfluxDB table name (measurement) for storing data. Required for 'json' and 'text' formats unless table_name_field is set.",
+            "description": "InfluxDB table name (measurement) for storing data. Required for all formats except 'lineprotocol', unless table_name_field is set.",
             "required": false
         },
         {
@@ -168,6 +234,7 @@
 }
 """
 
+import io
 import json
 import math
 import os
@@ -175,17 +242,12 @@ import re
 import time
 import tomllib
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-from confluent_kafka import (
-    Consumer,
-    KafkaError,
-    KafkaException,
-    Producer,
-    TopicPartition,
-)
+from confluent_kafka import (Consumer, KafkaError, KafkaException, Producer,
+                             TopicPartition)
 from jsonpath_ng.ext import parse as jsonpath_parse
 
 # Internal constants
@@ -199,6 +261,14 @@ _DEDUP_FIELD_NAME = "dedup_id"
 
 # Cache key for the KafkaManager reused across scheduled invocations
 _CACHE_CONSUMER = "kafka_consumer"
+# Cache key for the BinaryDecoder reused across scheduled invocations
+_CACHE_DECODER = "kafka_decoder"
+
+# Formats decoded from binary (value is raw bytes, not text). avro/jsonschema use
+# Schema Registry; protobuf uses a local .proto schema (Confluent wire framing).
+_BINARY_FORMATS = {"avro", "jsonschema", "protobuf"}
+# Binary formats whose schema is fetched from Schema Registry
+_REGISTRY_FORMATS = {"avro", "jsonschema"}
 
 _DURATION_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
 
@@ -215,6 +285,7 @@ _ENABLE_FULL_LOGGING: bool = True
 def _exc(e: BaseException) -> str:
     """Return exception detail when full logging is enabled, else the type name."""
     return str(e) if _ENABLE_FULL_LOGGING else type(e).__name__
+
 
 """
 Helper for batching multiple line protocol builders into a single write.
@@ -293,6 +364,18 @@ def convert_timestamp(value: Any, time_format: str) -> int:
     Raises:
         ValueError: If format is unknown or value cannot be converted
     """
+    # Avro/JSON Schema logical types may decode straight to a datetime.
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return int(value.timestamp() * 1_000_000_000)
+
+    # Avro 'date' logical type decodes to a datetime.date (checked after
+    # datetime, since datetime is a subclass of date).
+    if isinstance(value, date):
+        dt = datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1_000_000_000)
+
     if time_format == "ns":
         return int(value)
     elif time_format == "ms":
@@ -328,6 +411,36 @@ def parse_duration_seconds(value: str) -> int:
     return amount * _DURATION_UNITS[unit]
 
 
+def resolve_path(path: str, description: str) -> str:
+    """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR, falling back to server-derivable locations."""
+    if os.path.isabs(path):
+        return path
+
+    plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
+    if plugin_dir:
+        return os.path.join(plugin_dir, path)
+
+    # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
+    #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
+    #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
+    candidates: list[str] = []
+    if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
+        candidates.append(influxdb3_plugin_dir)
+    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+        candidates.append(str(Path(virtual_env).parent))
+
+    for base in candidates:
+        candidate = os.path.join(base, path)
+        if os.path.exists(candidate):
+            return candidate
+
+    raise ValueError(
+        f"PLUGIN_DIR environment variable not set and {description} path "
+        f"'{path}' was not found via fallbacks "
+        f"(tried: {', '.join(candidates) or 'none available'})."
+    )
+
+
 class KafkaConfig:
     """Configuration loader and validator for Kafka plugin"""
 
@@ -355,36 +468,6 @@ class KafkaConfig:
             self.config = self._build_config_from_args()
 
     @staticmethod
-    def _resolve_path(path: str, description: str) -> str:
-        """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR, falling back to server-derivable locations."""
-        if os.path.isabs(path):
-            return path
-
-        plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
-        if plugin_dir:
-            return os.path.join(plugin_dir, path)
-
-        # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
-        #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
-        #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
-        candidates: list[str] = []
-        if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
-            candidates.append(influxdb3_plugin_dir)
-        if virtual_env := os.environ.get("VIRTUAL_ENV"):
-            candidates.append(str(Path(virtual_env).parent))
-
-        for base in candidates:
-            candidate = os.path.join(base, path)
-            if os.path.exists(candidate):
-                return candidate
-
-        raise ValueError(
-            f"PLUGIN_DIR environment variable not set and {description} path "
-            f"'{path}' was not found via fallbacks "
-            f"(tried: {', '.join(candidates) or 'none available'})."
-        )
-
-    @staticmethod
     def _validate_topics(topics: list) -> None:
         """Reject regex topic subscriptions (leading '^')."""
         for topic in topics:
@@ -400,18 +483,15 @@ class KafkaConfig:
         for server in servers:
             if not isinstance(server, str) or not re.match(r"^[^,\s]+:\d+$", server):
                 raise ValueError(
-                    f"Invalid bootstrap server '{server}'. "
-                    f"Expected 'host:port' format."
+                    f"Invalid bootstrap server '{server}'. Expected 'host:port' format."
                 )
 
     def _load_toml_config(self, config_file: str) -> dict[str, Any]:
         """Load configuration from TOML file"""
         if not config_file.endswith(".toml"):
-            raise ValueError(
-                "Invalid config file format: expected a .toml file"
-            )
+            raise ValueError("Invalid config file format: expected a .toml file")
 
-        config_path: str = self._resolve_path(config_file, "configuration file")
+        config_path: str = resolve_path(config_file, "configuration file")
 
         try:
             with open(config_path, "rb") as f:
@@ -592,34 +672,53 @@ class KafkaConfig:
             self._validate_text_mapping(config)
         elif message_format == "lineprotocol":
             pass
+        elif message_format in _REGISTRY_FORMATS:
+            avro_config = kafka_config.get("avro")
+            if (
+                message_format == "avro"
+                and isinstance(avro_config, dict)
+                and avro_config.get("avro_schema_file")
+            ):
+                self._validate_avro_file(avro_config)
+            else:
+                self._validate_schema_registry(kafka_config.get("schema_registry"))
+            self._validate_json_mapping(config, message_format)
+        elif message_format == "protobuf":
+            pb_config = kafka_config.get("protobuf")
+            if isinstance(pb_config, dict) and pb_config.get("protobuf_schema_file"):
+                self._validate_protobuf(pb_config)
+            else:
+                self._validate_schema_registry(kafka_config.get("schema_registry"))
+            self._validate_json_mapping(config, message_format)
         else:
             raise ValueError(
-                f"Invalid message format: {message_format}. "
-                f"Supported formats: json, text, lineprotocol. "
-                f"Note: Protobuf and Avro are not supported (require Schema Registry)."
+                f"Invalid message format: {message_format}. Supported formats: "
+                f"json, text, lineprotocol, avro, jsonschema, protobuf."
             )
 
-    def _validate_json_mapping(self, config: dict[str, Any]):
-        """Validate JSON mapping configuration"""
-        if "mapping" not in config or "json" not in config["mapping"]:
-            raise ValueError("Missing required 'mapping.json' section in configuration")
+    def _validate_json_mapping(self, config: dict[str, Any], section: str = "json"):
+        """Validate a JSONPath-based mapping section (shared by json/avro/jsonschema)."""
+        if "mapping" not in config or section not in config["mapping"]:
+            raise ValueError(
+                f"Missing required 'mapping.{section}' section in configuration"
+            )
 
-        json_mapping: dict[str, Any] = config["mapping"]["json"]
+        json_mapping: dict[str, Any] = config["mapping"][section]
 
         if "table_name" not in json_mapping and "table_name_field" not in json_mapping:
             raise ValueError(
-                "Missing required parameter 'mapping.json.table_name' or "
-                "'mapping.json.table_name_field' in configuration"
+                f"Missing required parameter 'mapping.{section}.table_name' or "
+                f"'mapping.{section}.table_name_field' in configuration"
             )
 
         if "fields" not in json_mapping or not json_mapping["fields"]:
             raise ValueError(
-                "Missing required parameter 'mapping.json.fields' in configuration"
+                f"Missing required parameter 'mapping.{section}.fields' in configuration"
             )
 
         if "timestamp_field" in json_mapping:
             parsed_timestamp: dict[str, str] = self._validate_and_parse_timestamp_field(
-                json_mapping["timestamp_field"], "mapping.json.timestamp_field"
+                json_mapping["timestamp_field"], f"mapping.{section}.timestamp_field"
             )
             json_mapping["timestamp_config"] = parsed_timestamp
             del json_mapping["timestamp_field"]
@@ -630,10 +729,60 @@ class KafkaConfig:
                 dedup_id_field,
                 json_mapping.get("dedup_id_name"),
                 "json",
-                "mapping.json.dedup_id_field",
+                f"mapping.{section}.dedup_id_field",
             )
             json_mapping.pop("dedup_id_field", None)
             json_mapping.pop("dedup_id_name", None)
+
+    @staticmethod
+    def _validate_schema_registry(sr_config: dict[str, Any] | None) -> None:
+        """Validate the [kafka.schema_registry] section for binary formats."""
+        if not isinstance(sr_config, dict) or not sr_config.get("schema_registry_url"):
+            raise ValueError(
+                "Missing required 'kafka.schema_registry.schema_registry_url' for "
+                "binary formats (avro/jsonschema, or protobuf without "
+                "protobuf_schema_file)"
+            )
+
+        client_cert = sr_config.get("schema_registry_client_cert")
+        client_key = sr_config.get("schema_registry_client_key")
+        key_password = sr_config.get("schema_registry_client_key_password")
+        if (client_key or key_password) and not client_cert:
+            raise ValueError(
+                "'kafka.schema_registry.schema_registry_client_cert' is required "
+                "when 'schema_registry_client_key' or "
+                "'schema_registry_client_key_password' is set"
+            )
+
+    @staticmethod
+    def _validate_avro_file(avro_config: dict[str, Any] | None) -> None:
+        """Validate the [kafka.avro] section (local schemaless Avro schema)."""
+        if not isinstance(avro_config, dict) or not avro_config.get("avro_schema_file"):
+            raise ValueError(
+                "Missing required 'kafka.avro.avro_schema_file' for local "
+                "schemaless Avro decoding"
+            )
+        schema_file = avro_config["avro_schema_file"]
+        if not isinstance(schema_file, str) or not schema_file.endswith(
+            (".avsc", ".json")
+        ):
+            raise ValueError(
+                "'kafka.avro.avro_schema_file' must be a path to a .avsc or .json file"
+            )
+
+    @staticmethod
+    def _validate_protobuf(pb_config: dict[str, Any] | None) -> None:
+        """Validate the [kafka.protobuf] section (local .proto schema)."""
+        if not isinstance(pb_config, dict) or not pb_config.get("protobuf_schema_file"):
+            raise ValueError(
+                "Missing required 'kafka.protobuf.protobuf_schema_file' for the "
+                "protobuf format"
+            )
+        schema_file = pb_config["protobuf_schema_file"]
+        if not isinstance(schema_file, str) or not schema_file.endswith(".proto"):
+            raise ValueError(
+                "'kafka.protobuf.protobuf_schema_file' must be a path to a .proto file"
+            )
 
     def _validate_text_mapping(self, config: dict[str, Any]):
         """Validate text mapping configuration"""
@@ -701,7 +850,8 @@ class KafkaConfig:
 
         required_keys: list = ["topics", "bootstrap_servers", "group_id"]
 
-        if self.args.get("format", "json") in ["json", "text"]:
+        message_format: str = self.args.get("format", "json")
+        if message_format in ["json", "text"] or message_format in _BINARY_FORMATS:
             if not self.args.get("table_name_field"):
                 required_keys.append("table_name")
 
@@ -809,6 +959,21 @@ class KafkaConfig:
         if dlq_topic is not None and not dlq_topic.strip():
             raise ValueError("dlq_topic must be a non-empty string when set")
 
+        # Build schema source config; registry formats need a URL, protobuf a
+        # .proto file, and avro may use a local .avsc file (schemaless).
+        schema_registry_config: dict = self._build_schema_registry_from_args()
+        protobuf_config: dict = self._build_protobuf_from_args()
+        avro_config: dict = self._build_avro_from_args()
+        if message_format == "avro" and avro_config.get("avro_schema_file"):
+            self._validate_avro_file(avro_config)
+        elif message_format in _REGISTRY_FORMATS:
+            self._validate_schema_registry(schema_registry_config)
+        elif message_format == "protobuf":
+            if protobuf_config.get("protobuf_schema_file"):
+                self._validate_protobuf(protobuf_config)
+            else:
+                self._validate_schema_registry(schema_registry_config)
+
         return {
             "kafka": {
                 "bootstrap_servers": servers_list,
@@ -820,6 +985,9 @@ class KafkaConfig:
                 "security_protocol": security_protocol,
                 "sasl": sasl_config,
                 "ssl": ssl_config,
+                "schema_registry": schema_registry_config,
+                "protobuf": protobuf_config,
+                "avro": avro_config,
                 "max_poll_records": max_poll_records,
                 "max_poll_interval": max_poll_interval,
                 "dedup_window": dedup_window,
@@ -828,6 +996,47 @@ class KafkaConfig:
             },
             "mapping": self._build_mapping_from_args(),
         }
+
+    def _build_protobuf_from_args(self) -> dict[str, Any]:
+        """Build protobuf config from args. Keys match the [kafka.protobuf] TOML
+        keys, which are identical to the arg names."""
+        pb_config: dict[str, Any] = {}
+        for key in (
+            "protobuf_schema_file",
+            "protobuf_include_dir",
+            "protobuf_message_type",
+        ):
+            value = self.args.get(key)
+            if value:
+                pb_config[key] = value
+        return pb_config
+
+    def _build_avro_from_args(self) -> dict[str, Any]:
+        """Build local Avro config from args. Keys match the [kafka.avro] TOML
+        keys, which are identical to the arg names."""
+        avro_config: dict[str, Any] = {}
+        value = self.args.get("avro_schema_file")
+        if value:
+            avro_config["avro_schema_file"] = value
+        return avro_config
+
+    def _build_schema_registry_from_args(self) -> dict[str, Any]:
+        """Build Schema Registry config from args. Keys match the [kafka.schema_registry]
+        TOML keys, which are identical to the arg names."""
+        sr_config: dict[str, Any] = {}
+        for key in (
+            "schema_registry_url",
+            "schema_registry_username",
+            "schema_registry_password",
+            "schema_registry_ca_cert",
+            "schema_registry_client_cert",
+            "schema_registry_client_key",
+            "schema_registry_client_key_password",
+        ):
+            value = self.args.get(key)
+            if value:
+                sr_config[key] = value
+        return sr_config
 
     def _build_mapping_from_args(self) -> dict[str, Any]:
         """Build mapping configuration from args (supports JSON and text formats)"""
@@ -839,11 +1048,14 @@ class KafkaConfig:
             return self._build_text_mapping_from_args()
         elif message_format == "lineprotocol":
             return {}
+        elif message_format in _BINARY_FORMATS:
+            # Binary formats decode to a dict and reuse the JSONPath mapping.
+            json_mapping = self._build_json_mapping_from_args()
+            return {message_format: json_mapping["json"]}
         else:
             raise ValueError(
-                f"Unsupported format: {message_format}. "
-                f"Use 'json', 'text', or 'lineprotocol'. "
-                f"Note: Protobuf and Avro are not supported."
+                f"Unsupported format: {message_format}. Use 'json', 'text', "
+                f"'lineprotocol', 'avro', 'jsonschema', or 'protobuf'."
             )
 
     def _build_json_mapping_from_args(self) -> dict[str, Any]:
@@ -1079,6 +1291,8 @@ class KafkaManager:
         self.config: dict[str, Any] = config
         self.influxdb3_local = influxdb3_local
         self.task_id: str = task_id
+        # Binary formats keep the raw value bytes instead of a UTF-8 string.
+        self.binary: bool = config.get("format") in _BINARY_FORMATS
         self.consumer: Consumer | None = None
         self.producer: Producer | None = None  # Lazily created for DLQ
         self.connected: bool = False
@@ -1088,36 +1302,6 @@ class KafkaManager:
         # delivery callback confirms it. Reconciliation is scoped to _dlq_produced.
         self._dlq_status: dict[tuple[str, int, int], bool] = {}
         self._dlq_produced: set[tuple[str, int, int]] = set()
-
-    @staticmethod
-    def _resolve_path(path: str, description: str) -> str:
-        """Resolve path - absolute paths used as-is, relative paths resolved from PLUGIN_DIR, falling back to server-derivable locations."""
-        if os.path.isabs(path):
-            return path
-
-        plugin_dir: str | None = os.environ.get("PLUGIN_DIR")
-        if plugin_dir:
-            return os.path.join(plugin_dir, path)
-
-        # Fallbacks for servers where the operator has not exported PLUGIN_DIR:
-        #  - INFLUXDB3_PLUGIN_DIR: set when the server is configured via env var
-        #  - VIRTUAL_ENV: exported by the processing engine; default venv is <plugin-dir>/.venv
-        candidates: list[str] = []
-        if influxdb3_plugin_dir := os.environ.get("INFLUXDB3_PLUGIN_DIR"):
-            candidates.append(influxdb3_plugin_dir)
-        if virtual_env := os.environ.get("VIRTUAL_ENV"):
-            candidates.append(str(Path(virtual_env).parent))
-
-        for base in candidates:
-            candidate = os.path.join(base, path)
-            if os.path.exists(candidate):
-                return candidate
-
-        raise ValueError(
-            f"PLUGIN_DIR environment variable not set and {description} path "
-            f"'{path}' was not found via fallbacks "
-            f"(tried: {', '.join(candidates) or 'none available'})."
-        )
 
     @classmethod
     def build_security_config(cls, config: dict[str, Any]) -> dict[str, Any]:
@@ -1150,17 +1334,17 @@ class KafkaManager:
 
             ca_cert = ssl_config.get("ca_cert")
             if ca_cert:
-                client_config["ssl.ca.location"] = cls._resolve_path(
+                client_config["ssl.ca.location"] = resolve_path(
                     ca_cert, "CA certificate"
                 )
 
             client_cert = ssl_config.get("client_cert")
             client_key = ssl_config.get("client_key")
             if client_cert and client_key:
-                client_config["ssl.certificate.location"] = cls._resolve_path(
+                client_config["ssl.certificate.location"] = resolve_path(
                     client_cert, "client certificate"
                 )
-                client_config["ssl.key.location"] = cls._resolve_path(
+                client_config["ssl.key.location"] = resolve_path(
                     client_key, "client key"
                 )
 
@@ -1242,8 +1426,8 @@ class KafkaManager:
         source_topic: str,
         partition: int,
         offset: int,
-        key: str | None,
-        payload: str,
+        key: str | bytes | None,
+        payload: str | bytes | None,
         error_type: str,
         error_message: str,
     ) -> bool:
@@ -1268,8 +1452,14 @@ class KafkaManager:
         on_delivery = lambda err, msg, s=source: self._on_dlq_delivery(err, msg, s)
 
         try:
-            value_bytes = payload.encode("utf-8") if payload is not None else None
-            key_bytes = key.encode("utf-8") if key else None
+            if isinstance(payload, (bytes, bytearray)):
+                value_bytes = bytes(payload)
+            else:
+                value_bytes = payload.encode("utf-8") if payload is not None else None
+            if isinstance(key, (bytes, bytearray)):
+                key_bytes = bytes(key)
+            else:
+                key_bytes = key.encode("utf-8") if key else None
             try:
                 producer.produce(
                     dlq_topic,
@@ -1319,9 +1509,7 @@ class KafkaManager:
         # Scope to this cycle's keys so a late callback from a prior cycle
         # cannot trigger a spurious replay.
         return {
-            key
-            for key in self._dlq_produced
-            if not self._dlq_status.get(key, False)
+            key for key in self._dlq_produced if not self._dlq_status.get(key, False)
         }
 
     def connect(self) -> bool:
@@ -1401,27 +1589,39 @@ class KafkaManager:
                 self.influxdb3_local.error(f"[{self.task_id}] Kafka error: {error}")
                 return None
 
-        # Decode value
-        try:
-            value = (
-                msg.value().decode("utf-8", errors="replace") if msg.value() else None
-            )
-        except Exception:
+        raw_value = msg.value()
+        raw_key = msg.key()
+
+        # Binary formats are decoded later by the Schema Registry decoder, so
+        # keep the raw bytes here; text formats are decoded to a UTF-8 string.
+        if self.binary:
+            if not raw_value:
+                self.influxdb3_local.warn(
+                    f"[{self.task_id}] Skipping empty message on "
+                    f"{msg.topic()}:{msg.partition()}"
+                )
+                return None
             value = None
-
-        # Skip empty payloads
-        if not value or not value.strip():
-            self.influxdb3_local.warn(
-                f"[{self.task_id}] Skipping empty message on "
-                f"{msg.topic()}:{msg.partition()}"
-            )
-            return None
-
-        # Decode key
-        key = None
-        if msg.key():
+        else:
             try:
-                key = msg.key().decode("utf-8")
+                value = (
+                    raw_value.decode("utf-8", errors="replace") if raw_value else None
+                )
+            except Exception:
+                value = None
+
+            if not value or not value.strip():
+                self.influxdb3_local.warn(
+                    f"[{self.task_id}] Skipping empty message on "
+                    f"{msg.topic()}:{msg.partition()}"
+                )
+                return None
+
+        # Decode key to a string for logs / text DLQ; raw bytes kept for binary.
+        key = None
+        if raw_key:
+            try:
+                key = raw_key.decode("utf-8")
             except Exception:
                 pass
 
@@ -1431,6 +1631,8 @@ class KafkaManager:
             "offset": msg.offset(),
             "key": key,
             "payload": value,
+            "raw_value": raw_value,
+            "raw_key": raw_key,
             "timestamp": msg.timestamp()[1] if msg.timestamp() else None,
         }
 
@@ -1534,9 +1736,7 @@ class KafkaManager:
                     low, high = self.consumer.get_watermark_offsets(tp)
                     bootstrap = low if offset_reset == "earliest" else high
                     if bootstrap >= 0:
-                        tp_to_commit = TopicPartition(
-                            tp.topic, tp.partition, bootstrap
-                        )
+                        tp_to_commit = TopicPartition(tp.topic, tp.partition, bootstrap)
                         offsets_to_commit.append(tp_to_commit)
                 # else: poll failed and no valid position - skip this partition
                 #       so the previously committed offset stays intact.
@@ -1591,6 +1791,448 @@ class KafkaManager:
         self.connected = False
 
 
+class BinaryDecoder:
+    """Decode binary Kafka message values to a Python dict.
+
+    - avro / jsonschema: Confluent wire format, schema fetched from Schema
+      Registry by the embedded schema id.
+    - avro with avro_schema_file: raw schemaless Avro decoded with a local
+      .avsc schema (no wire header, registry is not contacted).
+    - protobuf: Confluent wire format, schema taken from a local .proto file
+      (registry is not contacted); the wire framing is parsed locally and the
+      message-index selects the message type.
+
+    Imports of the schema_registry / protobuf stacks are lazy so non-binary
+    formats don't require those extra dependencies. Reused across invocations
+    to keep the registry connection / compiled schema warm."""
+
+    def __init__(
+        self,
+        message_format: str,
+        kafka_config: dict[str, Any],
+        influxdb3_local,
+        task_id: str,
+    ):
+        self.message_format: str = message_format
+        self.influxdb3_local = influxdb3_local
+        self.task_id: str = task_id
+        self._serialization_context = None
+        self._value_field = None
+        self._deserializer = None
+        # protobuf state
+        self._pb = None
+        self._pb_pool = None
+        self._pb_file_name: str | None = None
+        self._pb_message_type: str | None = None
+        self._pb_client = None
+        self._pb_pool_cache = None
+        # local schemaless avro state
+        self._fastavro = None
+        self._avro_schema = None
+        avro_config = kafka_config.get("avro", {})
+        if message_format == "protobuf":
+            pb_config = kafka_config.get("protobuf", {})
+            if pb_config.get("protobuf_schema_file"):
+                self._build_protobuf(pb_config)
+            else:
+                self._build_protobuf_registry(
+                    kafka_config.get("schema_registry", {}), pb_config
+                )
+        elif message_format == "avro" and avro_config.get("avro_schema_file"):
+            self._build_avro_file(avro_config)
+        else:
+            self._build_registry(kafka_config.get("schema_registry", {}))
+
+    def rebind(self, influxdb3_local, task_id: str) -> None:
+        """Refresh per-invocation references when reusing a cached instance."""
+        self.influxdb3_local = influxdb3_local
+        self.task_id = task_id
+
+    def _build_registry(self, sr_config: dict[str, Any]) -> None:
+        """Construct the Schema Registry client and the per-format deserializer."""
+        client = self._build_sr_client(sr_config)
+
+        if self.message_format == "avro":
+            from confluent_kafka.schema_registry.avro import AvroDeserializer
+
+            self._deserializer = AvroDeserializer(client)
+        elif self.message_format == "jsonschema":
+            from confluent_kafka.schema_registry.json_schema import \
+                JSONDeserializer
+
+            self._deserializer = JSONDeserializer(None, schema_registry_client=client)
+        else:
+            raise ValueError(f"Unsupported registry format: {self.message_format}")
+
+    def _build_sr_client(self, sr_config: dict[str, Any]):
+        """Import the confluent SR stack and build a SchemaRegistryClient."""
+        try:
+            from confluent_kafka.schema_registry import SchemaRegistryClient
+            from confluent_kafka.serialization import (MessageField,
+                                                       SerializationContext)
+        except ImportError as e:
+            raise ValueError(
+                "Schema Registry support requires additional packages "
+                "(httpx, fastavro, jsonschema). Install them to use binary formats."
+            ) from e
+
+        self._serialization_context = SerializationContext
+        self._value_field = MessageField.VALUE
+        client = SchemaRegistryClient(self._build_client_conf(sr_config))
+
+        # Fail fast: verify the registry is reachable at construction time so a
+        # dead/misconfigured registry aborts the run before polling (and before
+        # any offset is committed) instead of failing on every message decode.
+        try:
+            client.get_subjects()
+        except Exception as e:
+            raise ValueError(
+                f"Schema Registry is not reachable at "
+                f"'{sr_config.get('schema_registry_url')}': {_exc(e)}"
+            ) from e
+        return client
+
+    @staticmethod
+    def _build_client_conf(sr_config: dict[str, Any]) -> dict[str, Any]:
+        """Map the schema_registry config to confluent SchemaRegistryClient keys."""
+        url = sr_config.get("schema_registry_url")
+        if not url:
+            raise ValueError(
+                "kafka.schema_registry.schema_registry_url is required for "
+                "binary formats"
+            )
+        if isinstance(url, list):
+            url = ",".join(url)
+
+        conf: dict[str, Any] = {"url": url}
+
+        username = sr_config.get("schema_registry_username")
+        if username:
+            password = sr_config.get("schema_registry_password") or ""
+            conf["basic.auth.user.info"] = f"{username}:{password}"
+
+        ca_cert = sr_config.get("schema_registry_ca_cert")
+        if ca_cert:
+            conf["ssl.ca.location"] = resolve_path(
+                ca_cert, "Schema Registry CA certificate"
+            )
+
+        client_cert = sr_config.get("schema_registry_client_cert")
+        if client_cert:
+            conf["ssl.certificate.location"] = resolve_path(
+                client_cert, "Schema Registry client certificate"
+            )
+
+        client_key = sr_config.get("schema_registry_client_key")
+        if client_key:
+            conf["ssl.key.location"] = resolve_path(
+                client_key, "Schema Registry client key"
+            )
+
+        key_password = sr_config.get("schema_registry_client_key_password")
+        if key_password:
+            conf["ssl.key.password"] = key_password
+
+        return conf
+
+    def _build_avro_file(self, avro_config: dict[str, Any]) -> None:
+        """Load a local .avsc schema for raw schemaless Avro decoding (cached)."""
+        try:
+            import fastavro
+        except ImportError as e:
+            raise ValueError(
+                "Local Avro support requires 'fastavro'. Install it to use the "
+                "avro format with avro_schema_file."
+            ) from e
+
+        schema_file = avro_config.get("avro_schema_file")
+        if not schema_file:
+            raise ValueError(
+                "kafka.avro.avro_schema_file is required for local schemaless "
+                "Avro decoding"
+            )
+        schema_path = resolve_path(schema_file, "avro schema file")
+        with open(schema_path) as f:
+            raw_schema = json.load(f)
+
+        self._fastavro = fastavro
+        self._avro_schema = fastavro.parse_schema(raw_schema)
+
+    def _build_protobuf(self, pb_config: dict[str, Any]) -> None:
+        """Compile the local .proto into a DescriptorPool (once, cached)."""
+        try:
+            from google.protobuf.json_format import MessageToDict
+            from google.protobuf.message_factory import GetMessageClass
+        except ImportError as e:
+            raise ValueError(
+                "Protobuf support requires 'protobuf' and 'grpcio-tools'. "
+                "Install them: influxdb3 install package grpcio-tools."
+            ) from e
+
+        self._pb = {
+            "MessageToDict": MessageToDict,
+            "GetMessageClass": GetMessageClass,
+        }
+        self._pb_message_type = pb_config.get("protobuf_message_type")
+
+        schema_file = pb_config.get("protobuf_schema_file")
+        if not schema_file:
+            raise ValueError(
+                "kafka.protobuf.protobuf_schema_file is required for the protobuf "
+                "format"
+            )
+        schema_path = resolve_path(schema_file, "protobuf schema file")
+
+        include_dir_cfg = pb_config.get("protobuf_include_dir")
+        include_dir = (
+            resolve_path(include_dir_cfg, "protobuf include dir")
+            if include_dir_cfg
+            else os.path.dirname(schema_path)
+        )
+
+        descriptor_set = self._compile_proto(schema_path, include_dir)
+        self._pb_pool = self._pool_from_descriptor_set(descriptor_set)
+        # The main file is the schema path relative to the include dir.
+        self._pb_file_name = os.path.relpath(schema_path, include_dir).replace(
+            os.sep, "/"
+        )
+
+    def _build_protobuf_registry(
+        self, sr_config: dict[str, Any], pb_config: dict[str, Any]
+    ) -> None:
+        """Set up protobuf decoding via Schema Registry: build the SR client and
+        a per-schema-id cache of compiled descriptor pools. The .proto text is
+        fetched and compiled on demand in _load_pb_schema."""
+        try:
+            from google.protobuf.json_format import MessageToDict
+            from google.protobuf.message_factory import GetMessageClass
+        except ImportError as e:
+            raise ValueError(
+                "Protobuf support requires 'protobuf' and 'grpcio-tools'. "
+                "Install them: influxdb3 install package grpcio-tools."
+            ) from e
+        from cachetools import LRUCache
+
+        self._pb = {
+            "MessageToDict": MessageToDict,
+            "GetMessageClass": GetMessageClass,
+        }
+        self._pb_message_type = pb_config.get("protobuf_message_type")
+        self._pb_client = self._build_sr_client(sr_config)
+        self._pb_pool_cache = LRUCache(maxsize=128)
+
+    def _load_pb_schema(self, schema_id: int):
+        """Fetch the .proto (and references) for schema_id from the registry,
+        compile it, and return (DescriptorPool, main_file_name). Cached by id."""
+        cached = self._pb_pool_cache.get(schema_id)
+        if cached is not None:
+            return cached
+
+        import shutil
+        import tempfile
+
+        schema = self._pb_client.get_schema(schema_id)
+
+        main_name = "__main__.proto"
+        root = tempfile.mkdtemp(prefix="pb_sr_")
+        try:
+            with open(os.path.join(root, main_name), "w") as f:
+                f.write(schema.schema_str)
+
+            written: set[str] = set()
+            for ref in schema.references or []:
+                self._materialize_reference(ref, root, written, 0)
+
+            descriptor_set = self._compile_proto(os.path.join(root, main_name), root)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+        pool = self._pool_from_descriptor_set(descriptor_set)
+        result = (pool, main_name)
+        self._pb_pool_cache[schema_id] = result
+        return result
+
+    def _materialize_reference(self, ref, root: str, written: set, depth: int) -> None:
+        """Fetch a referenced schema by subject/version and write it (and its own
+        references) under root at the path given by ref.name so 'import' resolves."""
+        if depth > 50:
+            raise ValueError(
+                "protobuf schema reference chain too deep (possible cycle)"
+            )
+        if not ref.name or ref.name in written:
+            return
+        written.add(ref.name)
+
+        registered = self._pb_client.get_version(ref.subject, ref.version)
+        ref_schema = registered.schema
+
+        # Guard against path traversal: the registry could return a reference
+        # name that is absolute or contains '..' and escape the temp root.
+        dest = os.path.join(root, ref.name)
+        root_real = os.path.realpath(root)
+        dest_real = os.path.realpath(dest)
+        if os.path.isabs(ref.name) or not (
+            dest_real == root_real or dest_real.startswith(root_real + os.sep)
+        ):
+            raise ValueError(f"Unsafe protobuf schema reference name: {ref.name!r}")
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w") as f:
+            f.write(ref_schema.schema_str)
+
+        for child in ref_schema.references or []:
+            self._materialize_reference(child, root, written, depth + 1)
+
+    @staticmethod
+    def _compile_proto(schema_path: str, include_dir: str) -> bytes:
+        """Compile a .proto into a serialized FileDescriptorSet via protoc."""
+        try:
+            import grpc_tools
+            from grpc_tools import protoc
+        except ImportError as e:
+            raise ValueError(
+                "Protobuf support requires 'grpcio-tools' to compile .proto files. "
+                "Install it: influxdb3 install package grpcio-tools."
+            ) from e
+
+        well_known = os.path.join(os.path.dirname(grpc_tools.__file__), "_proto")
+        rel_proto = os.path.relpath(schema_path, include_dir)
+
+        import tempfile
+
+        out_fd, out_path = tempfile.mkstemp(suffix=".desc")
+        os.close(out_fd)
+        try:
+            rc = protoc.main(
+                [
+                    "protoc",
+                    f"-I{include_dir}",
+                    f"-I{well_known}",
+                    "--include_imports",
+                    f"--descriptor_set_out={out_path}",
+                    rel_proto,
+                ]
+            )
+            if rc != 0:
+                raise ValueError(
+                    f"protoc failed to compile '{rel_proto}' (exit code {rc})"
+                )
+            with open(out_path, "rb") as f:
+                return f.read()
+        finally:
+            try:
+                os.unlink(out_path)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _pool_from_descriptor_set(descriptor_set: bytes):
+        """Build a DescriptorPool from a serialized FileDescriptorSet, adding
+        each file after its dependencies."""
+        from google.protobuf import descriptor_pb2
+        from google.protobuf.descriptor_pool import DescriptorPool
+
+        file_set = descriptor_pb2.FileDescriptorSet()
+        file_set.ParseFromString(descriptor_set)
+
+        pool = DescriptorPool()
+        files_by_name = {f.name: f for f in file_set.file}
+        added: set[str] = set()
+
+        def add_file(name: str) -> None:
+            if name in added or name not in files_by_name:
+                return
+            fdp = files_by_name[name]
+            for dep in fdp.dependency:
+                add_file(dep)
+            pool.Add(fdp)
+            added.add(name)
+
+        for fname in files_by_name:
+            add_file(fname)
+        return pool
+
+    def decode(self, raw_value: bytes | None, topic: str) -> dict | list:
+        """Decode a binary message value to a dict or list. Raises on empty
+        input or payloads that are neither an object nor an array."""
+        if not raw_value:
+            raise ValueError("Empty binary message value")
+
+        if self.message_format == "protobuf":
+            decoded = self._decode_protobuf(raw_value)
+        elif self._avro_schema is not None:
+            decoded = self._fastavro.schemaless_reader(
+                io.BytesIO(raw_value), self._avro_schema
+            )
+        else:
+            ctx = self._serialization_context(topic, self._value_field)
+            decoded = self._deserializer(raw_value, ctx)
+
+        if not isinstance(decoded, (dict, list)):
+            raise ValueError(
+                f"Decoded {self.message_format} message is not an object or "
+                f"array (got {type(decoded).__name__})"
+            )
+        return decoded
+
+    def _decode_protobuf(self, raw_value: bytes) -> dict:
+        """Parse the Confluent framing and decode with the local or registry
+        schema (registry schema chosen by the wire-frame schema id)."""
+        schema_id, message_indexes, payload = self._read_confluent_frame(raw_value)
+
+        if self._pb_pool_cache is not None:
+            pool, file_name = self._load_pb_schema(schema_id)
+        else:
+            pool, file_name = self._pb_pool, self._pb_file_name
+
+        if self._pb_message_type:
+            msg_desc = pool.FindMessageTypeByName(self._pb_message_type)
+        else:
+            file_desc = pool.FindFileByName(file_name)
+            top_level = list(file_desc.message_types_by_name.values())
+            msg_desc = top_level[message_indexes[0]]
+            for idx in message_indexes[1:]:
+                msg_desc = msg_desc.nested_types[idx]
+
+        message = self._pb["GetMessageClass"](msg_desc)()
+        message.ParseFromString(payload)
+        return self._pb["MessageToDict"](message, preserving_proto_field_name=True)
+
+    @staticmethod
+    def _read_confluent_frame(raw_value: bytes) -> tuple[int, list[int], bytes]:
+        """Read the Confluent protobuf wire format: magic byte (0), 4-byte schema
+        id, then a zigzag-varint message-index array. Returns
+        (schema_id, indexes, payload)."""
+        if len(raw_value) < 5 or raw_value[0] != 0:
+            raise ValueError(
+                "Message is not in Confluent protobuf wire format (bad magic byte)"
+            )
+
+        buf = io.BytesIO(raw_value)
+        buf.read(1)  # skip magic byte
+        schema_id = int.from_bytes(buf.read(4), "big")
+
+        def read_zigzag_varint() -> int:
+            result = 0
+            shift = 0
+            while True:
+                chunk = buf.read(1)
+                if not chunk:
+                    raise ValueError("Truncated message-index varint")
+                byte = chunk[0]
+                result |= (byte & 0x7F) << shift
+                if not (byte & 0x80):
+                    break
+                shift += 7
+            return (result >> 1) ^ -(result & 1)
+
+        size = read_zigzag_varint()
+        if size < 0 or size > 100000:
+            raise ValueError("Invalid message-index array length")
+        indexes = [0] if size == 0 else [read_zigzag_varint() for _ in range(size)]
+
+        return schema_id, indexes, buf.read()
+
+
 class JSONParser:
     """Parse JSON messages and convert to Line Protocol"""
 
@@ -1636,8 +2278,16 @@ class JSONParser:
     def parse(self, payload: str) -> list:
         """Parse JSON payload and return a list of (line, table, dedup_id) tuples."""
         try:
-            data: dict = json.loads(payload)
+            data = json.loads(payload)
+        except json.JSONDecodeError as e:
+            self.influxdb3_local.error(f"[{self.task_id}] Invalid JSON: {_exc(e)}")
+            raise
+        return self.parse_record(data)
 
+    def parse_record(self, data: Any) -> list:
+        """Map an already-decoded object (dict or list[dict]) to records. Used
+        directly for binary formats decoded via Schema Registry."""
+        try:
             if isinstance(data, list):
                 if len(data) == 0:
                     self.influxdb3_local.warn(
@@ -1676,13 +2326,12 @@ class JSONParser:
                 return [record] if record else []
 
             else:
-                raise ValueError(f"Unsupported JSON type: {type(data).__name__}")
+                raise ValueError(f"Unsupported record type: {type(data).__name__}")
 
-        except json.JSONDecodeError as e:
-            self.influxdb3_local.error(f"[{self.task_id}] Invalid JSON: {_exc(e)}")
-            raise
         except Exception as e:
-            self.influxdb3_local.error(f"[{self.task_id}] Error parsing JSON: {_exc(e)}")
+            self.influxdb3_local.error(
+                f"[{self.task_id}] Error parsing record: {_exc(e)}"
+            )
             raise
 
     def _parse_object(self, data: dict[str, Any]):
@@ -2121,7 +2770,9 @@ class TextParser:
             return [(line, table_name, dedup_id)]
 
         except Exception as e:
-            self.influxdb3_local.error(f"[{self.task_id}] Error parsing text: {_exc(e)}")
+            self.influxdb3_local.error(
+                f"[{self.task_id}] Error parsing text: {_exc(e)}"
+            )
             raise
 
     def _add_dedup_id(self, line, payload: str) -> str | None:
@@ -2423,15 +3074,19 @@ def process_scheduled_call(
                 "mapping": {
                     "json": config_loader.get_mapping_config("json"),
                     "text": config_loader.get_mapping_config("text"),
+                    "avro": config_loader.get_mapping_config("avro"),
+                    "jsonschema": config_loader.get_mapping_config("jsonschema"),
+                    "protobuf": config_loader.get_mapping_config("protobuf"),
                 },
             }
             influxdb3_local.cache.put("kafka_config", cached_config, 60 * 60)
-            # Config (re)built - drop any stale manager to pick up new settings.
+            # Config (re)built - drop any stale manager/decoder to pick up new settings.
             stale = influxdb3_local.cache.get(_CACHE_CONSUMER)
             if stale is not None:
                 stale.rebind(influxdb3_local, task_id)
                 stale.close()
                 influxdb3_local.cache.delete(_CACHE_CONSUMER)
+            influxdb3_local.cache.delete(_CACHE_DECODER)
             influxdb3_local.info(
                 f"[{task_id}] Kafka Plugin initialized, "
                 f"format: {cached_config['kafka']['format']}"
@@ -2441,7 +3096,7 @@ def process_scheduled_call(
             init_fmt: str = cached_config["kafka"]["format"]
             init_map: dict = (
                 cached_config["mapping"].get(init_fmt) or {}
-                if init_fmt in ("json", "text")
+                if init_fmt != "lineprotocol"
                 else {}
             )
             if init_map.get("dedup") and init_map.get("timestamp_config"):
@@ -2465,14 +3120,12 @@ def process_scheduled_call(
         # (a timestamp already lets InfluxDB dedup by tags + time).
         fmt_mapping: dict = (
             cached_config["mapping"].get(message_format) or {}
-            if message_format in ("json", "text")
+            if message_format != "lineprotocol"
             else {}
         )
         dedup_cfg: dict | None = fmt_mapping.get("dedup")
         dedup_active: bool = bool(dedup_cfg) and not fmt_mapping.get("timestamp_config")
-        dedup_field_name: str | None = (
-            dedup_cfg["field_name"] if dedup_active else None
-        )
+        dedup_field_name: str | None = dedup_cfg["field_name"] if dedup_active else None
         dedup_window_s: int = parse_duration_seconds(
             kafka_config.get("dedup_window", _DEFAULT_DEDUP_WINDOW)
         )
@@ -2500,6 +3153,29 @@ def process_scheduled_call(
             influxdb3_local.cache.put(_CACHE_CONSUMER, manager)
 
         manager.reset_cycle()
+
+        # Build/refresh the Schema Registry decoder for binary formats. Fail fast
+        # before polling so a misconfigured registry doesn't advance offsets.
+        binary: bool = message_format in _BINARY_FORMATS
+        decoder: BinaryDecoder | None = None
+        if binary:
+            decoder = influxdb3_local.cache.get(_CACHE_DECODER)
+            if decoder is not None:
+                decoder.rebind(influxdb3_local, task_id)
+            else:
+                try:
+                    decoder = BinaryDecoder(
+                        message_format,
+                        kafka_config,
+                        influxdb3_local,
+                        task_id,
+                    )
+                except Exception as e:
+                    influxdb3_local.error(
+                        f"[{task_id}] Failed to initialize binary decoder: {_exc(e)}"
+                    )
+                    return
+                influxdb3_local.cache.put(_CACHE_DECODER, decoder)
 
         # Retrieve messages
         messages: list = manager.get_messages()
@@ -2532,7 +3208,8 @@ def process_scheduled_call(
 
         influxdb3_local.info(f"[{task_id}] Processing {len(messages)} messages")
 
-        # Initialize parser based on format
+        # Initialize parser based on format. Binary formats decode to a dict and
+        # reuse JSONParser via its parse_record() entry point.
         if message_format == "json":
             mapping_config: dict = cached_config["mapping"].get("json", {})
             parser = JSONParser(mapping_config, task_id, influxdb3_local)
@@ -2541,6 +3218,9 @@ def process_scheduled_call(
         elif message_format == "text":
             mapping_config = cached_config["mapping"].get("text", {})
             parser = TextParser(mapping_config, task_id, influxdb3_local)
+        elif message_format in _BINARY_FORMATS:
+            mapping_config = cached_config["mapping"].get(message_format, {})
+            parser = JSONParser(mapping_config, task_id, influxdb3_local)
         else:
             influxdb3_local.error(
                 f"[{task_id}] Unknown message format: {message_format}"
@@ -2561,7 +3241,19 @@ def process_scheduled_call(
             stats.record_message_received(topic, partition, offset)
 
             try:
-                records: list = parser.parse(payload)
+                if binary:
+                    decoded = decoder.decode(msg.get("raw_value"), topic)
+                    if not decoded:
+                        records: list = []
+                        influxdb3_local.warn(
+                            f"[{task_id}] Binary message decoded to empty "
+                            f"content, no records produced: topic={topic} "
+                            f"partition={partition} offset={offset}"
+                        )
+                    else:
+                        records = parser.parse_record(decoded)
+                else:
+                    records = parser.parse(payload)
                 parse_results.append((msg, "ok", records))
             except Exception as e:
                 parse_results.append((msg, "fail", e))
@@ -2617,14 +3309,10 @@ def process_scheduled_call(
         write_failed: bool = False
         if all_line_builders:
             try:
-                influxdb3_local.write_sync(
-                    _BatchLines(all_line_builders), no_sync=True
-                )
+                influxdb3_local.write_sync(_BatchLines(all_line_builders), no_sync=True)
             except Exception as e:
                 write_failed = True
-                influxdb3_local.error(
-                    f"[{task_id}] Batch write failed: {_exc(e)}"
-                )
+                influxdb3_local.error(f"[{task_id}] Batch write failed: {_exc(e)}")
 
         # Phase 4: Update stats, route failures to DLQ, decide offset commit
         success_count: int = 0
@@ -2680,12 +3368,19 @@ def process_scheduled_call(
             if status == "fail":
                 # Poison message: offload to the DLQ; if it can't be offloaded,
                 # replay it so it is not lost. DLQ delivery is reconciled below.
+                # Binary formats forward the raw bytes byte-for-byte.
+                if binary:
+                    dlq_key = msg.get("raw_key")
+                    dlq_payload = msg.get("raw_value")
+                else:
+                    dlq_key = msg.get("key")
+                    dlq_payload = msg.get("payload", "")
                 if manager.send_to_dlq(
                     topic,
                     partition,
                     offset,
-                    msg.get("key"),
-                    msg.get("payload", ""),
+                    dlq_key,
+                    dlq_payload,
                     error_type,
                     error_msg,
                 ):
@@ -2739,6 +3434,7 @@ def process_scheduled_call(
     except Exception as e:
         influxdb3_local.error(f"[{task_id}] Error in Kafka plugin: {_exc(e)}")
         influxdb3_local.cache.delete("kafka_config")
+        influxdb3_local.cache.delete(_CACHE_DECODER)
         fatal = True
 
     finally:
@@ -2746,5 +3442,3 @@ def process_scheduled_call(
         if fatal and manager is not None:
             manager.close()
             influxdb3_local.cache.delete(_CACHE_CONSUMER)
-
-

--- a/influxdata/kafka_subscriber/manifest.toml
+++ b/influxdata/kafka_subscriber/manifest.toml
@@ -2,8 +2,8 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "kafka_subscriber"
-version = "0.3.0"
-description = "Enables real-time ingestion of Kafka messages into InfluxDB 3. Subscribe to Kafka topics and transform messages into time-series data with support for JSON, Line Protocol, and custom text formats."
+version = "0.4.0"
+description = "Enables real-time ingestion of Kafka messages into InfluxDB 3. Subscribe to Kafka topics and transform messages into time-series data with support for JSON, Line Protocol, custom text, Schema Registry binary formats (Avro, JSON Schema), and Protobuf via local .proto schemas."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"
 repository = "https://github.com/influxdata/influxdb3_plugins/tree/main/influxdata/kafka_subscriber"
@@ -16,4 +16,4 @@ exclude = [
 
 [dependencies]
 database_version = ">=3.8.2"
-python = ["confluent-kafka", "jsonpath-ng"]
+python = ["confluent-kafka>=2.15.0", "jsonpath-ng", "httpx", "fastavro", "jsonschema", "grpcio-tools>=1.54.0", "protobuf>=4.22.0", "authlib", "cachetools"]

--- a/influxdata/library/plugin_library.json
+++ b/influxdata/library/plugin_library.json
@@ -200,12 +200,12 @@
             {
                 "name": "Kafka Subscriber",
                 "path": "influxdata/kafka_subscriber/kafka_subscriber.py",
-                "description": "[BETA] Requires InfluxDB 3.8.2+. Enables real-time ingestion of Kafka messages into InfluxDB 3. Subscribe to Kafka topics and automatically transform messages into time-series data with support for JSON, Line Protocol, and custom text formats.",
+                "description": "[BETA] Requires InfluxDB 3.8.2+. Enables real-time ingestion of Kafka messages into InfluxDB 3. Subscribe to Kafka topics and automatically transform messages into time-series data with support for JSON, Line Protocol, custom text, Schema Registry binary formats (Avro, JSON Schema), and Protobuf via local .proto schemas.",
                 "author": "InfluxData",
                 "docs_file_link": "https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/kafka_subscriber/README.md",
                 "required_plugins": [],
-                "required_libraries": ["confluent-kafka", "jsonpath-ng"],
-                "last_update": "2026-03-06",
+                "required_libraries": ["confluent-kafka>=2.15.0", "jsonpath-ng", "httpx", "fastavro", "jsonschema", "grpcio-tools>=1.54.0", "protobuf>=4.22.0", "authlib", "cachetools"],
+                "last_update": "2026-07-07",
                 "trigger_types_supported": ["scheduler"]
             },
             {


### PR DESCRIPTION
New functionality:
  - Avro decoding via Confluent Schema Registry
  - Avro decoding via a local .avsc schema (raw schemaless, no registry)
  - JSON Schema decoding via Confluent Schema Registry
  - Protobuf decoding via a local .proto schema
  - Protobuf decoding via Confluent Schema Registry (fetches and compiles the .proto with references, cached per schema id)
  - Schema Registry client with basic-auth and mutual-TLS, with startup reachability check