### PR TITLE
feat(signal_generator): add timestamp jitter to simulate non-uniform sampling

### DIFF
--- a/influxdata/signal_generator/README.md
+++ b/influxdata/signal_generator/README.md
@@ -9,6 +9,7 @@ The Signal Generator Plugin lets new users produce realistic time-series data fo
 - **Zero dependencies**: Uses Python standard library only — no packages to install
 - **Composable waveforms**: Mix sine, square, triangle, sawtooth, noise, and spike signals by stacking them
 - **Realistic signals**: Default preset produces a signal centered at 30 with a slow sine trend, Gaussian noise, and occasional large spikes — immediately useful for alert testing
+- **Timestamp jitter**: Offsets point timestamps by default to simulate sensors that do not sample at perfectly uniform intervals
 - **Gap-filling**: Generates continuous, gapless data between executions regardless of trigger schedule
 - **Flexible output**: Configure measurement name, field name, and custom tags per trigger
 
@@ -41,7 +42,22 @@ This plugin has no required parameters.
 | `field`            | string       | `value`          | Output field name.                                                                           |
 | `tags`             | JSON string  | *(none)*         | Optional JSON object of tags to add to each data point. Example: `{"host": "server01"}`.    |
 | `points_per_second`| float        | `1.0`            | Data point resolution in points per second. Controls how many points are generated per second of elapsed time. |
+| `jitter_amplitude_seconds` | float | 10% of point interval | Maximum timestamp offset in seconds. Set to `0` to disable timestamp jitter. |
+| `jitter_seed`      | integer      | *(none)*         | Optional seed for reproducible per-timestamp jitter, mainly useful for tests.              |
 | `target_database`  | string       | *(none)*         | Optional target database. If omitted, writes to the trigger's own database.                 |
+
+### Timestamp jitter
+
+Timestamp jitter is enabled by default. If `jitter_amplitude_seconds` is omitted, the plugin uses 10% of the point interval:
+
+```text
+point_interval_seconds = 1 / points_per_second
+default_jitter_amplitude_seconds = 0.10 * point_interval_seconds
+```
+
+Each generated timestamp receives an independent random offset from `[-jitter_amplitude_seconds, +jitter_amplitude_seconds]`. When `jitter_seed` is set, the offset is derived from the seed and the nominal timestamp, so each timestamp still gets its own offset even if scheduled executions generate one point at a time. Waveforms are still evaluated at the nominal cadence timestamps, then jitter is applied only to the timestamp that is written. With the same waveform seeds, jittered and non-jittered runs produce the same field values.
+
+Set `jitter_amplitude_seconds=0` to preserve perfectly regular timestamps. The plugin rejects jitter settings that could produce duplicate or reordered timestamps.
 
 ### Waveform types
 
@@ -124,7 +140,8 @@ curl -X POST "http://localhost:8181/api/v3/configure/processing_engine_trigger" 
     "trigger_arguments": {
       "waveforms": "[{\"type\":\"constant\",\"value\":30.0},{\"type\":\"sine\",\"frequency\":0.005,\"amplitude\":10.0},{\"type\":\"noise\",\"stddev\":0.5}]",
       "measurement": "signal",
-      "field": "value"
+      "field": "value",
+      "jitter_amplitude_seconds": "0.2"
     },
     "trigger_settings": {
       "run_async": false,
@@ -331,16 +348,17 @@ Example with `tags={"host": "server01", "region": "us-west"}`:
 
 **Timestamp:**
 
-- Nanosecond precision Unix epoch timestamps. Each point's timestamp reflects the exact simulated time, not the wall-clock time of the write.
+- Nanosecond precision Unix epoch timestamps. Each point's timestamp reflects simulated sample time, not the wall-clock time of the write.
+- Timestamp jitter is enabled by default, so adjacent timestamps are usually close to, but not exactly on, the nominal cadence grid. Set `jitter_amplitude_seconds=0` for regular intervals.
 
 ### Line protocol examples
 
 Without tags (default):
 
 ```
-signal value=32.47 1712678400000000000
-signal value=31.89 1712678401000000000
-signal value=33.21 1712678402000000000
+signal value=32.47 1712678399918245021
+signal value=31.89 1712678401084217139
+signal value=33.21 1712678401962364102
 ```
 
 With custom measurement, field, and tags:
@@ -410,13 +428,14 @@ Entry point for scheduled triggers. Orchestrates the full execution: parses conf
 
 Key operations:
 
-1. Parses waveform, output, and resolution configuration from trigger arguments
+1. Parses waveform, output, resolution, and timestamp jitter configuration from trigger arguments
 2. Reads `last_time` from the trigger-local cache
 3. On first run: stores current time and returns without writing (initialization)
 4. Generates timestamps in the half-open interval `(last_time, now]`
-5. Evaluates the combined waveform at each timestamp
-6. Writes all points using `write_sync` with `no_sync=True`
-7. Updates `last_time` in the cache
+5. Evaluates the combined waveform at each nominal timestamp
+6. Applies timestamp jitter without changing field values
+7. Writes all points using `write_sync` with `no_sync=True`
+8. Updates `last_time` in the cache
 
 #### Waveform factories
 
@@ -429,6 +448,10 @@ Composes a list of waveform functions by summing their outputs: `combined(t) = s
 #### `generate_timestamps(start, end, points_per_second)`
 
 Generates timestamps in the half-open interval `(start, end]`. The interval is exclusive of `start` to prevent duplicate points across consecutive executions.
+
+#### `apply_timestamp_jitter(points, amplitude_seconds, seed)`
+
+Offsets generated point timestamps after signal evaluation. Values are unchanged; only timestamps are moved.
 
 ## Troubleshooting
 
@@ -464,6 +487,12 @@ echo '[{"type": "sine"}, {"type": "noise"}]' | python3 -m json.tool
 **Cause**: The trigger fires more frequently than `1 / points_per_second` seconds, so no timestamps fall in the interval.
 
 **Solution**: Increase `points_per_second` to match your trigger frequency, or reduce trigger frequency. For example, if firing every 1 s with `points_per_second=1.0`, at least one point is generated per execution. If firing every 100ms, increase to `points_per_second=10.0`.
+
+#### Issue: Invalid jitter config in logs
+
+**Cause**: `jitter_amplitude_seconds` is negative, non-numeric, or too large for the configured `points_per_second`, or `jitter_seed` is not an integer.
+
+**Solution**: Reduce `jitter_amplitude_seconds`, reduce `points_per_second`, set `jitter_amplitude_seconds=0`, or use an integer `jitter_seed`. The plugin requires at least a 1 microsecond minimum gap between any two possible jittered timestamps.
 
 #### Issue: Write failures for individual points
 

--- a/influxdata/signal_generator/manifest.toml
+++ b/influxdata/signal_generator/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "signal_generator"
-version = "0.1.0"
+version = "0.2.0"
 description = "Generates configurable waveform-based time-series data on a schedule for demos, testing, dashboards, alerts, and downstream plugin validation without requiring an external data source."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/signal_generator/signal_generator.py
+++ b/influxdata/signal_generator/signal_generator.py
@@ -33,6 +33,18 @@
             "required": false
         },
         {
+            "name": "jitter_amplitude_seconds",
+            "example": "0.2",
+            "description": "Maximum timestamp offset in seconds. Defaults to 10% of the point interval. Set to 0 to disable timestamp jitter.",
+            "required": false
+        },
+        {
+            "name": "jitter_seed",
+            "example": "42",
+            "description": "Optional integer seed for reproducible per-timestamp jitter.",
+            "required": false
+        },
+        {
             "name": "target_database",
             "example": "my_db",
             "description": "Optional target database. If omitted, writes to the trigger's database.",
@@ -42,8 +54,9 @@
 }
 """
 
-import math
+import hashlib
 import json
+import math
 import random
 import uuid
 from typing import Iterable, Optional, Protocol, runtime_checkable
@@ -165,6 +178,9 @@ DEFAULT_WAVEFORMS = [
     {"type": "spike", "probability": 0.005, "min_amplitude": 8.0, "max_amplitude": 15.0},
 ]
 
+DEFAULT_JITTER_INTERVAL_FRACTION = 0.10
+MIN_JITTER_GAP_SECONDS = 1e-6
+
 
 # ---------------------------------------------------------------------------
 # Config parsing
@@ -240,9 +256,54 @@ def parse_points_per_second(args):
         value = float(raw)
     except (ValueError, TypeError):
         return None
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0:
         return None
     return value
+
+
+def parse_jitter_config(args, points_per_second):
+    """Parse timestamp jitter config from trigger args.
+    Returns ((amplitude_seconds, seed), None) on success,
+    or (None, error_message) on error.
+    """
+    if args is None:
+        args = {}
+
+    interval = 1.0 / points_per_second
+    raw_amplitude = args.get("jitter_amplitude_seconds")
+    if raw_amplitude is None:
+        amplitude = DEFAULT_JITTER_INTERVAL_FRACTION * interval
+    else:
+        try:
+            amplitude = float(raw_amplitude)
+        except (ValueError, TypeError):
+            return (None, "Invalid jitter config: jitter_amplitude_seconds must be a float")
+
+    if not math.isfinite(amplitude) or amplitude < 0:
+        return (None, f"Invalid jitter config: amplitude {amplitude}s must be finite and >= 0")
+
+    raw_seed = args.get("jitter_seed")
+    if raw_seed is None:
+        seed = None
+    else:
+        try:
+            if isinstance(raw_seed, bool):
+                raise ValueError
+            if isinstance(raw_seed, float) and not raw_seed.is_integer():
+                raise ValueError
+            seed = int(raw_seed)
+        except (ValueError, TypeError):
+            return (None, "Invalid jitter config: jitter_seed must be an integer")
+
+    if interval - (2 * amplitude) < MIN_JITTER_GAP_SECONDS:
+        return (
+            None,
+            f"Invalid jitter config: amplitude {amplitude}s must satisfy "
+            f"interval ({interval}s) - 2*amplitude >= 1us; reduce "
+            f"jitter_amplitude_seconds or points_per_second",
+        )
+
+    return ((amplitude, seed), None)
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +328,32 @@ def generate_signal(waveform_fn, timestamps):
     Returns a list of (timestamp, value) tuples.
     """
     return [(t, waveform_fn(t)) for t in timestamps]
+
+
+def _rng_for_timestamp(seed, timestamp):
+    timestamp_ns = int(round(timestamp * 1_000_000_000))
+    payload = f"{seed}:{timestamp_ns}".encode("ascii")
+    digest = hashlib.blake2b(payload, digest_size=8).digest()
+    return random.Random(int.from_bytes(digest, "big"))
+
+
+def apply_timestamp_jitter(points, amplitude_seconds, seed=None):
+    """Apply independent timestamp offsets to points without changing values."""
+    if amplitude_seconds == 0:
+        return list(points)
+
+    if seed is None:
+        rng = random.Random()
+        return [
+            (t + rng.uniform(-amplitude_seconds, amplitude_seconds), value)
+            for t, value in points
+        ]
+
+    jittered = []
+    for t, value in points:
+        rng = _rng_for_timestamp(seed, t)
+        jittered.append((t + rng.uniform(-amplitude_seconds, amplitude_seconds), value))
+    return jittered
 
 
 # ---------------------------------------------------------------------------
@@ -376,6 +463,11 @@ def process_scheduled_call(influxdb3_local, call_time, args=None):
         influxdb3_local.error(f"[{task_id}] Failed to parse points_per_second")
         return
 
+    jitter_config, jitter_error = parse_jitter_config(args, pps)
+    if jitter_config is None:
+        influxdb3_local.error(f"[{task_id}] {jitter_error}")
+        return
+
     # --- Check cache for last execution time ---
     last_time = get_last_time(influxdb3_local.cache)
     if last_time is None:
@@ -393,6 +485,8 @@ def process_scheduled_call(influxdb3_local, call_time, args=None):
         return
 
     points = generate_signal(combined, timestamps)
+    jitter_amplitude_seconds, jitter_seed = jitter_config
+    points = apply_timestamp_jitter(points, jitter_amplitude_seconds, jitter_seed)
 
     try:
         written = write_points(influxdb3_local, points, measurement, field, tags, target_database)

--- a/influxdata/signal_generator/test_signal_generator.py
+++ b/influxdata/signal_generator/test_signal_generator.py
@@ -474,6 +474,73 @@ def test_parse_points_per_second_negative():
     assert result is None
 
 
+def test_parse_points_per_second_nan():
+    from signal_generator import parse_points_per_second
+    result = parse_points_per_second({"points_per_second": "nan"})
+    assert result is None
+
+
+def test_parse_jitter_config_default():
+    from signal_generator import parse_jitter_config
+    config, error = parse_jitter_config(None, points_per_second=2.0)
+    assert error is None
+    amplitude, seed = config
+    assert abs(amplitude - 0.05) < 1e-12
+    assert seed is None
+
+
+def test_parse_jitter_config_custom():
+    from signal_generator import parse_jitter_config
+    config, error = parse_jitter_config(
+        {"jitter_amplitude_seconds": "0.2", "jitter_seed": "42"},
+        points_per_second=1.0,
+    )
+    assert error is None
+    assert config == (0.2, 42)
+
+
+def test_parse_jitter_config_zero_disables_jitter():
+    from signal_generator import parse_jitter_config
+    config, error = parse_jitter_config({"jitter_amplitude_seconds": "0"}, points_per_second=1.0)
+    assert error is None
+    assert config == (0.0, None)
+
+
+def test_parse_jitter_config_negative_amplitude():
+    from signal_generator import parse_jitter_config
+    config, error = parse_jitter_config({"jitter_amplitude_seconds": "-0.1"}, points_per_second=1.0)
+    assert config is None
+    assert "Invalid jitter config" in error
+
+
+def test_parse_jitter_config_non_numeric_amplitude():
+    from signal_generator import parse_jitter_config
+    config, error = parse_jitter_config({"jitter_amplitude_seconds": "abc"}, points_per_second=1.0)
+    assert config is None
+    assert "Invalid jitter config" in error
+
+
+def test_parse_jitter_config_nan_amplitude():
+    from signal_generator import parse_jitter_config
+    config, error = parse_jitter_config({"jitter_amplitude_seconds": "nan"}, points_per_second=1.0)
+    assert config is None
+    assert "Invalid jitter config" in error
+
+
+def test_parse_jitter_config_non_integer_seed():
+    from signal_generator import parse_jitter_config
+    config, error = parse_jitter_config({"jitter_seed": "1.5"}, points_per_second=1.0)
+    assert config is None
+    assert "Invalid jitter config" in error
+
+
+def test_parse_jitter_config_rejects_duplicate_timestamp_risk():
+    from signal_generator import parse_jitter_config
+    config, error = parse_jitter_config({"jitter_amplitude_seconds": "0.5"}, points_per_second=1.0)
+    assert config is None
+    assert "Invalid jitter config" in error
+
+
 # ---------------------------------------------------------------------------
 # Time series generation tests
 # ---------------------------------------------------------------------------
@@ -518,6 +585,59 @@ def test_generate_signal_empty():
     fn = make_constant(1.0)
     points = generate_signal(fn, [])
     assert points == []
+
+
+def test_apply_timestamp_jitter_seeded_exact_offsets():
+    from signal_generator import apply_timestamp_jitter
+    points = [(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)]
+    jittered = apply_timestamp_jitter(points, 0.1, seed=7)
+    expected_timestamps = [
+        0.9814723333052915,
+        2.031738647558769,
+        3.047601008781658,
+    ]
+    assert [value for _, value in jittered] == [10.0, 20.0, 30.0]
+    for (timestamp, _), expected in zip(jittered, expected_timestamps):
+        assert abs(timestamp - expected) < 1e-12
+
+
+def test_apply_timestamp_jitter_seeded_independent_of_batching():
+    from signal_generator import apply_timestamp_jitter
+    points = [(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)]
+    batched = apply_timestamp_jitter(points, 0.1, seed=7)
+    individual = [
+        apply_timestamp_jitter([point], 0.1, seed=7)[0]
+        for point in points
+    ]
+    assert batched == individual
+
+
+def test_apply_timestamp_jitter_seeded_single_point_calls_vary_by_timestamp():
+    from signal_generator import apply_timestamp_jitter
+    points = [(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)]
+    offsets = [
+        apply_timestamp_jitter([point], 0.1, seed=7)[0][0] - point[0]
+        for point in points
+    ]
+    assert len(set(offsets)) == len(offsets)
+
+
+def test_apply_timestamp_jitter_zero_is_identical():
+    from signal_generator import apply_timestamp_jitter
+    points = [(1.0, 10.0), (2.0, 20.0)]
+    assert apply_timestamp_jitter(points, 0.0, seed=7) == points
+
+
+def test_apply_timestamp_jitter_preserves_strict_order_for_valid_config():
+    from signal_generator import apply_timestamp_jitter, generate_timestamps
+    timestamps = generate_timestamps(0.0, 10.0, 1.0)
+    points = [(t, t * 2) for t in timestamps]
+    jittered = apply_timestamp_jitter(points, 0.1, seed=99)
+    jittered_timestamps = [timestamp for timestamp, _ in jittered]
+    assert all(
+        earlier < later
+        for earlier, later in zip(jittered_timestamps, jittered_timestamps[1:])
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -607,6 +727,17 @@ def count_written_points(mock):
     return total
 
 
+def written_timestamps_ns(mock):
+    timestamps = []
+    for batch in mock.written_lines:
+        lines = batch.build().split("\n")
+        timestamps.extend(int(line.rsplit(" ", 1)[1]) for line in lines)
+    for _, batch in mock.written_to_db:
+        lines = batch.build().split("\n")
+        timestamps.extend(int(line.rsplit(" ", 1)[1]) for line in lines)
+    return timestamps
+
+
 def test_process_scheduled_call_first_run(monkeypatch):
     import signal_generator
     monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
@@ -690,3 +821,110 @@ def test_process_scheduled_call_updates_cache(monkeypatch):
     cached_after_second = mock.cache.get("signal_gen:last_time")
     # Cache should be updated to second call time
     assert cached_after_second > cached_after_first
+
+
+def test_process_scheduled_call_jitter_zero_keeps_regular_timestamps(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    args = {
+        "waveforms": '[{"type":"constant","value":1.0}]',
+        "jitter_amplitude_seconds": "0",
+    }
+    first_time = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    process_scheduled_call(mock, first_time, args)
+    second_time = datetime(2026, 4, 10, 12, 0, 3, tzinfo=timezone.utc)
+    process_scheduled_call(mock, second_time, args)
+    base_ns = int(first_time.timestamp() * 1_000_000_000)
+    assert written_timestamps_ns(mock) == [
+        base_ns + 1_000_000_000,
+        base_ns + 2_000_000_000,
+        base_ns + 3_000_000_000,
+    ]
+
+
+def test_process_scheduled_call_seeded_jitter_offsets_timestamps(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    args = {
+        "waveforms": '[{"type":"constant","value":1.0}]',
+        "jitter_amplitude_seconds": "0.1",
+        "jitter_seed": "7",
+    }
+    first_time = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    process_scheduled_call(mock, first_time, args)
+    second_time = datetime(2026, 4, 10, 12, 0, 3, tzinfo=timezone.utc)
+    process_scheduled_call(mock, second_time, args)
+    assert written_timestamps_ns(mock) == [
+        1775822401062348800,
+        1775822402047160576,
+        1775822403008397312,
+    ]
+
+
+def test_process_scheduled_call_seeded_jitter_varies_across_one_point_calls(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    args = {
+        "waveforms": '[{"type":"constant","value":1.0}]',
+        "jitter_amplitude_seconds": "0.1",
+        "jitter_seed": "7",
+    }
+    first_time = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    process_scheduled_call(mock, first_time, args)
+    for seconds in [1, 2, 3]:
+        process_scheduled_call(
+            mock,
+            datetime(2026, 4, 10, 12, 0, seconds, tzinfo=timezone.utc),
+            args,
+        )
+
+    timestamps = written_timestamps_ns(mock)
+    deltas = [
+        later - earlier
+        for earlier, later in zip(timestamps, timestamps[1:])
+    ]
+    assert deltas != [1_000_000_000, 1_000_000_000]
+
+
+def test_process_scheduled_call_invalid_jitter_logs_and_writes_nothing(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    args = {"jitter_amplitude_seconds": "0.5"}
+    call_time = datetime(2026, 4, 10, 12, 0, 0)
+    process_scheduled_call(mock, call_time, args)
+    assert len(mock.written_lines) == 0
+    assert mock.cache.get("signal_gen:last_time") is None
+    assert any("Invalid jitter config" in log for log in mock.logs["error"])
+
+
+def test_process_scheduled_call_default_jitter_offsets_timestamps(monkeypatch):
+    import signal_generator
+    monkeypatch.setattr(signal_generator, "LineBuilder", MockLineBuilder)
+    from signal_generator import process_scheduled_call
+    mock = MockInfluxDB3Local()
+    args = {"waveforms": '[{"type":"constant","value":1.0}]'}
+    first_time = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    process_scheduled_call(mock, first_time, args)
+    second_time = datetime(2026, 4, 10, 12, 0, 3, tzinfo=timezone.utc)
+    process_scheduled_call(mock, second_time, args)
+
+    timestamps = written_timestamps_ns(mock)
+    assert len(timestamps) == 3
+    base_ns = int(first_time.timestamp() * 1_000_000_000)
+    nominal = [base_ns + i * 1_000_000_000 for i in (1, 2, 3)]
+    # Default amplitude is 10% of the 1s interval.
+    for timestamp, nominal_ns in zip(timestamps, nominal):
+        assert abs(timestamp - nominal_ns) <= 100_000_000
+    assert timestamps != nominal
+    assert all(
+        earlier < later
+        for earlier, later in zip(timestamps, timestamps[1:])
+    )


### PR DESCRIPTION
## Summary
- Adds `jitter_amplitude_seconds` and `jitter_seed` trigger args to `signal_generator` plugin, offsetting generated point timestamps to mimic real sensors that don't sample on a perfect grid.
- Jitter is on by default (10% of the point interval); set `jitter_amplitude_seconds=0` for perfectly regular timestamps. Config rejected if it could produce duplicate/reordered timestamps.
- Field values are unaffected — waveforms still evaluate at nominal cadence, jitter only moves the written timestamp.
- Bumps manifest version to 0.2.0, updates README, adds unit tests.