### PR TITLE
fix(registry): shorten plugin descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .claude
 .context
+.worktrees/
 *.pyc

--- a/influxdata/kafka_subscriber/manifest.toml
+++ b/influxdata/kafka_subscriber/manifest.toml
@@ -3,7 +3,7 @@ manifest_schema_version = "1.2"
 [plugin]
 name = "kafka_subscriber"
 version = "0.4.0"
-description = "Enables real-time ingestion of Kafka messages into InfluxDB 3. Subscribe to Kafka topics and transform messages into time-series data with support for JSON, Line Protocol, custom text, Schema Registry binary formats (Avro, JSON Schema), and Protobuf via local .proto schemas."
+description = "Ingests Kafka messages into InfluxDB 3 with JSON, Line Protocol, text, Avro, JSON Schema, and Protobuf decoding, plus Schema Registry and local schema support."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"
 repository = "https://github.com/influxdata/influxdb3_plugins/tree/main/influxdata/kafka_subscriber"

--- a/influxdata/simple_data_replicator/manifest.toml
+++ b/influxdata/simple_data_replicator/manifest.toml
@@ -3,7 +3,7 @@ manifest_schema_version = "1.2"
 [plugin]
 name = "simple_data_replicator"
 version = "0.1.0"
-description = "Replicates data from a local InfluxDB 3 Core/Enterprise instance to a remote InfluxDB 3 instance over HTTP, with table/field filtering and renaming. Supports scheduler and data write trigger modes, buffering data in a compressed queue with automatic retries."
+description = "Replicates data between InfluxDB 3 instances over HTTP with table and field filtering, renaming, scheduler/write triggers, and compressed retry queue buffering."
 triggers = ["process_writes", "process_scheduled_call"]
 homepage = "https://www.influxdata.com/"
 repository = "https://github.com/influxdata/influxdb3_plugins/tree/main/influxdata/simple_data_replicator"


### PR DESCRIPTION
- add .worktrees/ to .gitignore 
- shorten kafka_subscriber and simple_data_replicator manifest descriptions to satisfy the 200-character registry schema limit