### PR TITLE
fix(utils): Preserve explicit database values in write_data

### DIFF
--- a/influxdata-plugin-utils/src/influxdata_plugin_utils/write.py
+++ b/influxdata-plugin-utils/src/influxdata_plugin_utils/write.py
@@ -192,11 +192,11 @@ def write_data(
     attempts = max(retries, 0) + 1
 
     if no_sync is None:
-        if database:
+        if database is not None:
             write_fn = partial(influxdb3_local.write_to_db, database)
         else:
             write_fn = influxdb3_local.write
-    elif database:
+    elif database is not None:
         write_fn = partial(influxdb3_local.write_sync_to_db, database, no_sync=no_sync)
     else:
         write_fn = partial(influxdb3_local.write_sync, no_sync=no_sync)


### PR DESCRIPTION

- route write_data through cross-db write methods whenever database is not None
- preserve explicit empty/invalid database strings so the engine can validate them

We need this because `None` is the sentinel for “use the trigger DB.” Any explicit string value, including an empty or invalid database name, should take the cross-db path so the engine can validate it and return the correct error instead of silently writing to the trigger DB.