### PR TITLE
Declare notifier plugin dependencies

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -17,7 +17,7 @@ env:
   PLUGIN_ROOT: influxdata
   REGISTRY_RELEASE: registry
   SDK_REPO: influxdata/influxdb3-plugin-sdk
-  SDK_VERSION: v0.5.0
+  SDK_VERSION: v0.6.0
   EXCLUDE_DIRS: "library"
   GH_TOKEN: ${{ github.token }}
 

--- a/influxdata/forecast_error_evaluator/manifest.toml
+++ b/influxdata/forecast_error_evaluator/manifest.toml
@@ -1,4 +1,4 @@
-manifest_schema_version = "1.2"
+manifest_schema_version = "1.3"
 
 [plugin]
 name = "forecast_error_evaluator"
@@ -17,3 +17,8 @@ exclude = [
 [dependencies]
 database_version = ">=3.0.0"
 python = ["pandas", "requests"]
+
+[[dependencies.plugins]]
+index_url = "https://github.com/influxdata/influxdb3_plugins/releases/download/registry/index.json"
+name = "notifier"
+version = ">=1.0.0,<2.0.0"

--- a/influxdata/mad_check/manifest.toml
+++ b/influxdata/mad_check/manifest.toml
@@ -1,4 +1,4 @@
-manifest_schema_version = "1.2"
+manifest_schema_version = "1.3"
 
 [plugin]
 name = "mad_check"
@@ -17,3 +17,8 @@ exclude = [
 [dependencies]
 database_version = ">=3.0.0"
 python = ["requests"]
+
+[[dependencies.plugins]]
+index_url = "https://github.com/influxdata/influxdb3_plugins/releases/download/registry/index.json"
+name = "notifier"
+version = ">=1.0.0,<2.0.0"

--- a/influxdata/prophet_forecasting/manifest.toml
+++ b/influxdata/prophet_forecasting/manifest.toml
@@ -1,4 +1,4 @@
-manifest_schema_version = "1.2"
+manifest_schema_version = "1.3"
 
 [plugin]
 name = "prophet_forecasting"
@@ -17,3 +17,8 @@ exclude = [
 [dependencies]
 database_version = ">=3.0.0"
 python = ["pandas", "requests", "prophet", "numpy"]
+
+[[dependencies.plugins]]
+index_url = "https://github.com/influxdata/influxdb3_plugins/releases/download/registry/index.json"
+name = "notifier"
+version = ">=1.0.0,<2.0.0"

--- a/influxdata/state_change/manifest.toml
+++ b/influxdata/state_change/manifest.toml
@@ -1,4 +1,4 @@
-manifest_schema_version = "1.2"
+manifest_schema_version = "1.3"
 
 [plugin]
 name = "state_change"
@@ -17,3 +17,8 @@ exclude = [
 [dependencies]
 database_version = ">=3.0.0"
 python = ["requests"]
+
+[[dependencies.plugins]]
+index_url = "https://github.com/influxdata/influxdb3_plugins/releases/download/registry/index.json"
+name = "notifier"
+version = ">=1.0.0,<2.0.0"

--- a/influxdata/stateless_adtk_detector/manifest.toml
+++ b/influxdata/stateless_adtk_detector/manifest.toml
@@ -1,4 +1,4 @@
-manifest_schema_version = "1.2"
+manifest_schema_version = "1.3"
 
 [plugin]
 name = "stateless_adtk_detector"
@@ -17,3 +17,8 @@ exclude = [
 [dependencies]
 database_version = ">=3.0.0"
 python = ["requests", "adtk", "pandas"]
+
+[[dependencies.plugins]]
+index_url = "https://github.com/influxdata/influxdb3_plugins/releases/download/registry/index.json"
+name = "notifier"
+version = ">=1.0.0,<2.0.0"

--- a/influxdata/threshold_deadman_checks/manifest.toml
+++ b/influxdata/threshold_deadman_checks/manifest.toml
@@ -1,4 +1,4 @@
-manifest_schema_version = "1.2"
+manifest_schema_version = "1.3"
 
 [plugin]
 name = "threshold_deadman_checks"
@@ -17,3 +17,8 @@ exclude = [
 [dependencies]
 database_version = ">=3.0.0"
 python = ["requests"]
+
+[[dependencies.plugins]]
+index_url = "https://github.com/influxdata/influxdb3_plugins/releases/download/registry/index.json"
+name = "notifier"
+version = ">=1.0.0,<2.0.0"


### PR DESCRIPTION
## Summary

- Bump notifier-dependent plugin manifests to `manifest_schema_version = "1.3"`.
- Add `dependencies.plugins` entries pointing at the published `notifier` plugin.
- Update the registry publishing workflow to use SDK `v0.6.0`, which supports schema 1.3 and `dependencies.plugins`.


