### PR TITLE
fix(signal-generator): shorten description

### DIFF
--- a/influxdata/signal_generator/manifest.toml
+++ b/influxdata/signal_generator/manifest.toml
@@ -3,7 +3,7 @@ manifest_schema_version = "1.2"
 [plugin]
 name = "signal_generator"
 version = "0.3.0"
-description = "Generates configurable waveform-based time-series data on a schedule for demos, testing, dashboards, alerts, and downstream plugin validation without requiring an external data source. Simulates data-source outage gaps by default."
+description = "Generates scheduled, configurable waveform time-series data for demos, testing, dashboards, alerts, and plugin validation without external sources. Simulates outage gaps by default."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"
 repository = "https://github.com/influxdata/influxdb3_plugins/tree/main/influxdata/signal_generator"


### PR DESCRIPTION
Shorten the Signal Generator manifest description to satisfy the 200-character registry schema limit.