### PR TITLE
chore: bump notifier dependency plugin versions

### DIFF
--- a/influxdata/forecast_error_evaluator/manifest.toml
+++ b/influxdata/forecast_error_evaluator/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.3"
 
 [plugin]
 name = "forecast_error_evaluator"
-version = "1.1.0"
+version = "1.2.0"
 description = "Evaluates accuracy of forecast models by comparing predicted values with actual observations. Computes error metrics and detects anomalies based on elevated errors with multi-channel notifications."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/mad_check/manifest.toml
+++ b/influxdata/mad_check/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.3"
 
 [plugin]
 name = "mad_check"
-version = "1.1.0"
+version = "1.2.0"
 description = "Provides Median Absolute Deviation (MAD)-based anomaly detection using data writes trigger. Maintains in-memory deques for efficient computation and supports count-based and duration-based thresholds."
 triggers = ["process_writes"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/prophet_forecasting/manifest.toml
+++ b/influxdata/prophet_forecasting/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.3"
 
 [plugin]
 name = "prophet_forecasting"
-version = "1.1.0"
+version = "1.2.0"
 description = "Provides time series forecasting capabilities for InfluxDB 3 data using the Prophet library."
 triggers = ["process_scheduled_call", "process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/state_change/manifest.toml
+++ b/influxdata/state_change/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.3"
 
 [plugin]
 name = "state_change"
-version = "1.1.0"
+version = "1.2.0"
 description = "Provides field change and threshold monitoring capabilities through scheduler and data writes plugins. Detects changes in field values or threshold conditions with customizable notification templates."
 triggers = ["process_writes", "process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/stateless_adtk_detector/manifest.toml
+++ b/influxdata/stateless_adtk_detector/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.3"
 
 [plugin]
 name = "stateless_adtk_detector"
-version = "1.1.0"
+version = "1.2.0"
 description = "Provides anomaly detection capabilities for time series data using the ADTK library. Supports multiple stateless detectors with consensus-based detection and customizable notification messages."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/threshold_deadman_checks/manifest.toml
+++ b/influxdata/threshold_deadman_checks/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.3"
 
 [plugin]
 name = "threshold_deadman_checks"
-version = "1.1.0"
+version = "1.2.0"
 description = "Provides comprehensive monitoring capabilities including deadman alerts and aggregation-based threshold checks. Supports both scheduler and data write triggers with multi-channel notifications."
 triggers = ["process_writes", "process_scheduled_call"]
 homepage = "https://www.influxdata.com/"


### PR DESCRIPTION
Bump the six plugin manifests changed in #120 to trigger publishing workflow 