### PR TITLE
fix: add missing frontmatter trigger args

### DIFF
--- a/influxdata/downsampler/README.md
+++ b/influxdata/downsampler/README.md
@@ -16,38 +16,42 @@ If a plugin supports multiple trigger specifications, some parameters may depend
 
 This plugin includes a JSON metadata schema in its docstring that defines supported trigger types and configuration parameters. This metadata enables the [InfluxDB 3 Explorer](https://docs.influxdata.com/influxdb3/explorer/) UI to display and configure the plugin.
 
-### Required parameters
+### Scheduled trigger parameters
 
-| Parameter            | Type   | Default                   | Description                                                                        |
-|----------------------|--------|---------------------------|------------------------------------------------------------------------------------|
-| `source_measurement` | string | required                  | Source measurement containing data to downsample                                   |
-| `target_measurement` | string | required                  | Destination measurement for downsampled data                                       |
-| `window`             | string | required (scheduled only) | Time window for each downsampling job. Format: `<number><unit>` (e.g., "1h", "1d") |
+| Parameter            | Type    | Default    | Description                                                                                                                                                                               |
+|----------------------|---------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `source_measurement` | string  | required   | Source measurement containing data to downsample                                                                                                                                          |
+| `target_measurement` | string  | required   | Destination measurement for downsampled data                                                                                                                                              |
+| `window`             | string  | required   | Time window for each downsampling job. Format: `<number><unit>` (for example, "1h", "1d")                                                                                               |
+| `interval`           | string  | "10min"    | Time interval for downsampling. Format: `<number><unit>` (for example, "10min", "2h", "1d")                                                                                             |
+| `calculations`       | string  | "avg"      | Aggregation functions. Single function or dot-separated field:aggregation pairs                                                                                                           |
+| `specific_fields`    | string  | all fields | Dot-separated list of fields to downsample (for example, "co.temperature")                                                                                                               |
+| `excluded_fields`    | string  | none       | Dot-separated list of fields and tags to exclude from downsampling results                                                                                                                |
+| `tag_values`         | string  | none       | Tag filters. Format: `tag:value1@value2@value3` for multiple values                                                                                                                       |
+| `offset`             | string  | "0"        | Time offset to apply to the window                                                                                                                                                        |
+| `target_database`    | string  | "default"  | Database for storing downsampled data                                                                                                                                                     |
+| `max_retries`        | integer | 5          | Maximum number of retries for write operations                                                                                                                                            |
+| `enable_full_logging` | boolean | false      | When `true`, full exception messages are written to logs. When `false` (default), only the exception type is logged, to avoid leaking sensitive values. Enable temporarily for debugging. |
 
-### Aggregation parameters
+### HTTP request parameters
 
-| Parameter         | Type   | Default    | Description                                                                          |
-|-------------------|--------|------------|--------------------------------------------------------------------------------------|
-| `interval`        | string | "10min"    | Time interval for downsampling. Format: `<number><unit>` (e.g., "10min", "2h", "1d") |
-| `calculations`    | string | "avg"      | Aggregation functions. Single function or dot-separated field:aggregation pairs      |
-| `specific_fields` | string | all fields | Dot-separated list of fields to downsample (e.g., "co.temperature")                  |
-| `excluded_fields` | string | none       | Dot-separated list of fields and tags to exclude from downsampling results           |
+Send these parameters as JSON in the HTTP POST request body:
 
-### Filtering parameters
-
-| Parameter    | Type   | Default | Description                                                         |
-|--------------|--------|---------|---------------------------------------------------------------------|
-| `tag_values` | string | none    | Tag filters. Format: `tag:value1@value2@value3` for multiple values |
-| `offset`     | string | "0"     | Time offset to apply to the window                                  |
-
-### Advanced parameters
-
-| Parameter             | Type    | Default   | Description                                                                                                                                                                               |
-|-----------------------|---------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `target_database`     | string  | "default" | Database for storing downsampled data                                                                                                                                                     |
-| `max_retries`         | integer | 5         | Maximum number of retries for write operations                                                                                                                                            |
-| `batch_size`          | string  | "30d"     | Time interval for batch processing (HTTP mode only)                                                                                                                                       |
-| `enable_full_logging` | boolean | false     | When `true`, full exception messages are written to logs. When `false` (default), only the exception type is logged, to avoid leaking sensitive values. Enable temporarily for debugging. |
+| Parameter             | Type    | Default      | Description                                                                                                                                                                               |
+|-----------------------|---------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `source_measurement`  | string  | required     | Source measurement containing data to downsample                                                                                                                                          |
+| `target_measurement`  | string  | required     | Destination measurement for downsampled data                                                                                                                                              |
+| `interval`            | string  | "10min"      | Time interval for downsampling. Format: `<number><unit>` (for example, "10min", "2h", "1d")                                                                                             |
+| `batch_size`          | string  | "30d"        | Time interval for each HTTP backfill batch                                                                                                                                                |
+| `calculations`        | string/array | "avg"    | Aggregation functions. Use `"avg"` for all fields, or an array of `[field, aggregation]` pairs                                                                                            |
+| `specific_fields`     | array   | all fields   | List of fields to downsample                                                                                                                                                              |
+| `excluded_fields`     | array   | none         | List of fields and tags to exclude from downsampling results                                                                                                                              |
+| `tag_values`          | object  | none         | Tag filters as an object mapping tag names to lists of values                                                                                                                             |
+| `target_database`     | string  | "default"    | Database for storing downsampled data                                                                                                                                                     |
+| `max_retries`         | integer | 5            | Maximum number of retries for write operations                                                                                                                                            |
+| `backfill_start`      | string  | oldest point | ISO 8601 datetime with timezone for the start of the HTTP backfill window                                                                                                                 |
+| `backfill_end`        | string  | current time | ISO 8601 datetime with timezone for the end of the HTTP backfill window                                                                                                                   |
+| `enable_full_logging` | boolean | false        | When `true`, full exception messages are written to logs. When `false` (default), only the exception type is logged, to avoid leaking sensitive values. Enable temporarily for debugging. |
 
 ### TOML configuration
 
@@ -237,7 +241,7 @@ Key operations:
 3. Applies time-based aggregation with specified functions
 4. Writes downsampled data with metadata columns
 
-#### `process_http_request(influxdb3_local, request_body, args)`
+#### `process_request(influxdb3_local, query_parameters, request_headers, request_body, args)`
 
 Handles HTTP-triggered on-demand downsampling. Processes batch downsampling with configurable time ranges for backfill scenarios.
 
@@ -248,9 +252,9 @@ Key operations:
 3. Applies aggregation functions to historical data
 4. Returns processing statistics and results
 
-#### `aggregate_data(data, interval, calculations)`
+#### `build_downsample_query(fields_list, measurement, tags_list, interval, tag_values, start_time, end_time)`
 
-Core aggregation engine that applies statistical functions to time-series data.
+Builds the SQL query that applies time bucketing, tag filters, grouping, and aggregation functions to source data.
 
 Supported aggregation functions:
 

--- a/influxdata/downsampler/downsampler.py
+++ b/influxdata/downsampler/downsampler.py
@@ -80,6 +80,86 @@
             "description": "When true, full exception details (messages) are written to logs. When false (default), only the exception type is logged to avoid leaking sensitive values. Default: false.",
             "required": false
         }
+    ],
+    "http_args_config": [
+        {
+            "name": "source_measurement",
+            "example": "metrics",
+            "description": "Name of the source measurement to downsample.",
+            "required": true
+        },
+        {
+            "name": "target_measurement",
+            "example": "metrics_daily",
+            "description": "Name of the target measurement to write downsampled data.",
+            "required": true
+        },
+        {
+            "name": "interval",
+            "example": "1d",
+            "description": "Time interval for downsampling batches. Units: 's', 'min', 'h', 'd', 'w', 'm', 'q', 'y'. Default: 10min.",
+            "required": false
+        },
+        {
+            "name": "batch_size",
+            "example": "7d",
+            "description": "Time interval for each HTTP backfill batch. Units: 's', 'min', 'h', 'd', 'w', 'm', 'q', 'y'. Default: 30d.",
+            "required": false
+        },
+        {
+            "name": "calculations",
+            "example": [["cpu_usage", "avg"], ["memory_usage", "max"]],
+            "description": "Aggregation functions. Use 'avg' for all fields, or a list of [field, aggregation] pairs. Valid functions: avg, sum, min, max, median, count, stddev, first_value, last_value, var, approx_median.",
+            "required": false
+        },
+        {
+            "name": "specific_fields",
+            "example": ["cpu_usage", "memory_usage"],
+            "description": "List of field names to downsample.",
+            "required": false
+        },
+        {
+            "name": "excluded_fields",
+            "example": ["status", "host"],
+            "description": "List of field and tag names to exclude from downsampling results.",
+            "required": false
+        },
+        {
+            "name": "tag_values",
+            "example": {"host": ["server1", "server2"]},
+            "description": "Tag filters as a JSON object mapping tag names to lists of allowed values.",
+            "required": false
+        },
+        {
+            "name": "max_retries",
+            "example": "5",
+            "description": "Maximum number of retries for write operations.",
+            "required": false
+        },
+        {
+            "name": "target_database",
+            "example": "analytics",
+            "description": "Target database for writing downsampled data. If not provided, uses the trigger's database.",
+            "required": false
+        },
+        {
+            "name": "backfill_start",
+            "example": "2024-01-01T00:00:00+00:00",
+            "description": "ISO 8601 datetime with timezone for the start of the HTTP backfill window. If omitted, starts from the oldest source point.",
+            "required": false
+        },
+        {
+            "name": "backfill_end",
+            "example": "2024-01-31T00:00:00+00:00",
+            "description": "ISO 8601 datetime with timezone for the end of the HTTP backfill window. Default: current time.",
+            "required": false
+        },
+        {
+            "name": "enable_full_logging",
+            "example": "true",
+            "description": "When true, full exception details (messages) are written to logs. When false (default), only the exception type is logged to avoid leaking sensitive values. Default: false.",
+            "required": false
+        }
     ]
 }
 """

--- a/influxdata/downsampler/manifest.toml
+++ b/influxdata/downsampler/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "downsampler"
-version = "1.2.0"
+version = "1.3.0"
 description = "Enables downsampling of data in InfluxDB 3 with flexible configuration for time intervals, field aggregations, tag filtering, and batch processing. Supports scheduler and HTTP trigger modes."
 triggers = ["process_scheduled_call", "process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/influxdb_to_iceberg/influxdb_to_iceberg.py
+++ b/influxdata/influxdb_to_iceberg/influxdb_to_iceberg.py
@@ -56,6 +56,68 @@
             "description": "Automatically update Iceberg table schema when data doesn't match existing schema (default: false).",
             "required": false
         }
+    ],
+    "http_args_config": [
+        {
+            "name": "measurement",
+            "example": "temperature",
+            "description": "Source measurement containing data to transfer.",
+            "required": true
+        },
+        {
+            "name": "catalog_configs",
+            "example": {"type": "sql", "uri": "sqlite:///path/to/catalog.db"},
+            "description": "Iceberg catalog configuration dictionary passed to PyIceberg load_catalog.",
+            "required": true
+        },
+        {
+            "name": "included_fields",
+            "example": ["temp_celsius", "humidity", "sensor_id"],
+            "description": "List of field and tag names to include in replication.",
+            "required": false
+        },
+        {
+            "name": "excluded_fields",
+            "example": ["usage_system"],
+            "description": "List of field and tag names to exclude from replication.",
+            "required": false
+        },
+        {
+            "name": "namespace",
+            "example": "weather",
+            "description": "Iceberg namespace for the target table. Default: default.",
+            "required": false
+        },
+        {
+            "name": "table_name",
+            "example": "temperature_metrics",
+            "description": "Iceberg table name. Default: same as measurement.",
+            "required": false
+        },
+        {
+            "name": "batch_size",
+            "example": "12h",
+            "description": "Batch size duration for HTTP processing. Format: <number><unit> where unit is s, min, h, d, or w. Default: 1d.",
+            "required": false
+        },
+        {
+            "name": "backfill_start",
+            "example": "2024-01-01T00:00:00+00:00",
+            "description": "ISO 8601 datetime with timezone for the start of the HTTP backfill window. If omitted, starts from the oldest source point.",
+            "required": false
+        },
+        {
+            "name": "backfill_end",
+            "example": "2024-01-07T00:00:00+00:00",
+            "description": "ISO 8601 datetime with timezone for the end of the HTTP backfill window. Default: current time.",
+            "required": false
+        },
+        {
+            "name": "auto_update_schema",
+            "example": "true",
+            "description": "Automatically update Iceberg table schema when data doesn't match existing schema. Default: false.",
+            "required": false
+        }
     ]
 }
 """

--- a/influxdata/influxdb_to_iceberg/manifest.toml
+++ b/influxdata/influxdb_to_iceberg/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "influxdb_to_iceberg"
-version = "1.1.0"
+version = "1.2.0"
 description = "Transfers data from InfluxDB 3 to Apache Iceberg tables with automatic schema management, customizable namespace and table naming, field filtering, and batch processing support."
 triggers = ["process_scheduled_call", "process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/notifier/manifest.toml
+++ b/influxdata/notifier/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "notifier"
-version = "1.0.0"
+version = "1.1.0"
 description = "Notification dispatcher that sends notifications through various channels (Slack, Discord, HTTP, SMS, WhatsApp) based on incoming HTTP requests. Features retry logic and environment variable support."
 triggers = ["process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/notifier/notifier_plugin.py
+++ b/influxdata/notifier/notifier_plugin.py
@@ -1,6 +1,20 @@
 """
 {
-    "plugin_type": ["http"]
+    "plugin_type": ["http"],
+    "http_args_config": [
+        {
+            "name": "notification_text",
+            "example": "Alert: High CPU usage detected on server1",
+            "description": "Text content of the notification message in the HTTP request body.",
+            "required": true
+        },
+        {
+            "name": "senders_config",
+            "example": {"slack": {"slack_webhook_url": "https://hooks.slack.com/services/...", "slack_headers": "eyJDb250ZW50LVR5cGUiOiAiYXBwbGljYXRpb24vanNvbiJ9"}, "sms": {"twilio_from_number": "+19876543210", "twilio_to_number": "+1234567890"}},
+            "description": "HTTP request body object mapping sender names to channel-specific configuration. Supported senders: slack (slack_webhook_url, slack_headers), discord (discord_webhook_url, discord_headers), http (http_webhook_url, http_headers), sms and whatsapp (twilio_sid, twilio_token, twilio_from_number, twilio_to_number). Twilio credentials may also come from TWILIO_SID and TWILIO_TOKEN.",
+            "required": true
+        }
+    ]
 }
 """
 

--- a/influxdata/prophet_forecasting/manifest.toml
+++ b/influxdata/prophet_forecasting/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.3"
 
 [plugin]
 name = "prophet_forecasting"
-version = "1.2.0"
+version = "1.3.0"
 description = "Provides time series forecasting capabilities for InfluxDB 3 data using the Prophet library."
 triggers = ["process_scheduled_call", "process_request"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/prophet_forecasting/prophet_forecasting.py
+++ b/influxdata/prophet_forecasting/prophet_forecasting.py
@@ -212,6 +212,122 @@
             "description": "Path to config file to override args. Format: 'config.toml'.",
             "required": false
         }
+    ],
+    "http_args_config": [
+        {
+            "name": "measurement",
+            "example": "temperature",
+            "description": "Source InfluxDB measurement name to query historical data from.",
+            "required": true
+        },
+        {
+            "name": "field",
+            "example": "value",
+            "description": "Field name within the measurement to forecast.",
+            "required": true
+        },
+        {
+            "name": "forecast_horizont",
+            "example": "7d",
+            "description": "Forecast horizon duration. Format: <number><unit> where unit is s, min, h, d, w, m, q, or y.",
+            "required": true
+        },
+        {
+            "name": "tag_values",
+            "example": {"region": "us-west", "device": "sensor1"},
+            "description": "Tag filters for the InfluxDB query as a JSON object.",
+            "required": true
+        },
+        {
+            "name": "target_measurement",
+            "example": "temperature_forecast",
+            "description": "Destination measurement name to write forecast points.",
+            "required": true
+        },
+        {
+            "name": "unique_suffix",
+            "example": "model_v1_20250722",
+            "description": "Unique identifier for model versioning and storage.",
+            "required": true
+        },
+        {
+            "name": "start_time",
+            "example": "2025-05-20T00:00:00+00:00",
+            "description": "Historical window start time as an ISO 8601 datetime with timezone.",
+            "required": true
+        },
+        {
+            "name": "end_time",
+            "example": "2025-06-19T00:00:00+00:00",
+            "description": "Historical window end time as an ISO 8601 datetime with timezone.",
+            "required": true
+        },
+        {
+            "name": "seasonality_mode",
+            "example": "additive",
+            "description": "Prophet seasonality mode: additive or multiplicative. Default: additive.",
+            "required": false
+        },
+        {
+            "name": "changepoint_prior_scale",
+            "example": "0.05",
+            "description": "Flexibility of trend changepoints. Default: 0.05.",
+            "required": false
+        },
+        {
+            "name": "changepoints",
+            "example": ["2025-01-01", "2025-06-01"],
+            "description": "List of changepoint dates or datetimes in ISO format.",
+            "required": false
+        },
+        {
+            "name": "save_mode",
+            "example": "true",
+            "description": "Whether to save or load a persisted model using unique_suffix. Default: false.",
+            "required": false
+        },
+        {
+            "name": "validation_window",
+            "example": "3d",
+            "description": "Duration for validation window. Defaults to 0s (no validation). Format: <number><unit>.",
+            "required": false
+        },
+        {
+            "name": "msre_threshold",
+            "example": "0.05",
+            "description": "Maximum acceptable Mean Squared Relative Error for validation. Defaults to infinity.",
+            "required": false
+        },
+        {
+            "name": "target_database",
+            "example": "forecast_db",
+            "description": "Optional InfluxDB database name for writing forecast results.",
+            "required": false
+        },
+        {
+            "name": "holiday_date_list",
+            "example": ["2025-01-01", "2025-12-25"],
+            "description": "List of custom holiday dates in ISO format.",
+            "required": false
+        },
+        {
+            "name": "holiday_names",
+            "example": ["New Year", "Christmas"],
+            "description": "List of names corresponding to holiday_date_list.",
+            "required": false
+        },
+        {
+            "name": "holiday_country_names",
+            "example": ["US", "UK"],
+            "description": "List of country codes or names for built-in Prophet holidays.",
+            "required": false
+        },
+        {
+            "name": "inferred_freq",
+            "example": "1D",
+            "description": "Manually specified frequency. If omitted, frequency is inferred from data.",
+            "required": false
+        }
     ]
 }
 """

--- a/influxdata/sagemaker/manifest.toml
+++ b/influxdata/sagemaker/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "sagemaker"
-version = "0.2.0"
+version = "0.3.0"
 description = "Runs scheduled inference against Amazon SageMaker endpoints using recent InfluxDB 3 rows and writes prediction results back to InfluxDB."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"

--- a/influxdata/sagemaker/sagemaker.py
+++ b/influxdata/sagemaker/sagemaker.py
@@ -95,7 +95,7 @@
         {
             "name": "tag_values",
             "example": "sensor_id:A1@A2.env:prod",
-            "description": "Optional tag filter applied to the source query. Syntax: 'tag1:val1@val2.tag2:val3'. Dot separates tag pairs; colon separates tag from values; @ separates multiple values for the same tag; values may be quoted (\\"foo\\" or 'foo') to include special characters. Tags with a single value are also written to the output line; tags with multiple values are filtered in the query but not written.",
+            "description": "Optional tag filter applied to the source query. Syntax: 'tag1:val1@val2.tag2:val3'. Dot separates tag pairs; colon separates tag from values; @ separates multiple values for the same tag; values may be quoted with double or single quotes to include special characters. Tags with a single value are also written to the output line; tags with multiple values are filtered in the query but not written.",
             "required": false
         },
         {


### PR DESCRIPTION
## Summary
- Add missing HTTP frontmatter arg configs for downsampler, influxdb_to_iceberg, notifier, and prophet_forecasting.
- Fix SageMaker frontmatter wording so metadata parses from both raw source text and Python docstrings.
- Document Notifier nested sender configuration keys in the HTTP metadata.
- Update Downsampler README HTTP parameters for backfill_start/backfill_end and correct stale function references.