### PR TITLE
chore(plugins): bump plugin utils to 0.3

### DIFF
--- a/influxdata/gapfill/README.md
+++ b/influxdata/gapfill/README.md
@@ -180,7 +180,7 @@ plugin) turns gapfill into a sensor-health monitor.
 2. Install the Python dependencies into the plugin environment:
 
    ```bash
-   influxdb3 install package "influxdata-plugin-utils>=0.2.0"
+   influxdb3 install package "influxdata-plugin-utils>=0.3.0"
    influxdb3 install package scipy
    ```
 
@@ -342,7 +342,7 @@ report rows.
 
 **Cause**: The plugin environment lacks `scipy` or `influxdata-plugin-utils`.
 
-**Solution**: Run `influxdb3 install package "influxdata-plugin-utils>=0.2.0"`
+**Solution**: Run `influxdb3 install package "influxdata-plugin-utils>=0.3.0"`
 and `influxdb3 install package scipy`, then re-enable the trigger.
 
 #### Issue: Field type conflict on write

--- a/influxdata/gapfill/manifest.toml
+++ b/influxdata/gapfill/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "gapfill"
-version = "0.1.0"
+version = "0.2.0"
 description = "Detects gaps in time series and fills them with imputed values using configurable interpolation methods, with optional fill marking and per-gap quality reports. Supports scheduled and HTTP backfill."
 triggers = ["process_scheduled_call", "process_request"]
 homepage = "https://www.influxdata.com/"
@@ -16,4 +16,4 @@ exclude = [
 
 [dependencies]
 database_version = ">=3.8.2"
-python = ["influxdata-plugin-utils>=0.2.0", "scipy"]
+python = ["influxdata-plugin-utils>=0.3.0", "scipy"]

--- a/influxdata/gapfill/requirements.txt
+++ b/influxdata/gapfill/requirements.txt
@@ -1,2 +1,2 @@
-influxdata-plugin-utils>=0.2.0
+influxdata-plugin-utils>=0.3.0
 scipy

--- a/influxdata/resampler/README.md
+++ b/influxdata/resampler/README.md
@@ -90,7 +90,7 @@ grid node is written only when it has a source point on each side at most
 
 - **InfluxDB 3 Core/Enterprise**: with the Processing Engine enabled
 - **Python packages** (declared in `manifest.toml`):
-  - `influxdata-plugin-utils>=0.2.0`
+  - `influxdata-plugin-utils>=0.3.0`
   - `scipy` (installs `numpy`)
 
 ## Installation steps
@@ -108,7 +108,7 @@ grid node is written only when it has a source point on each side at most
 2. Install required Python packages:
 
    ```bash
-   influxdb3 install package "influxdata-plugin-utils>=0.2.0"
+   influxdb3 install package "influxdata-plugin-utils>=0.3.0"
    influxdb3 install package scipy
    ```
 

--- a/influxdata/resampler/manifest.toml
+++ b/influxdata/resampler/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.2"
 
 [plugin]
 name = "resampler"
-version = "0.1.0"
+version = "0.2.0"
 description = "Resamples time series with non-uniform timestamps onto a uniform time grid via configurable interpolation, or snaps timestamps to grid nodes keeping values and types unchanged."
 triggers = ["process_scheduled_call"]
 homepage = "https://www.influxdata.com/"
@@ -16,4 +16,4 @@ exclude = [
 
 [dependencies]
 database_version = ">=3.8.2"
-python = ["influxdata-plugin-utils>=0.2.0", "scipy"]
+python = ["influxdata-plugin-utils>=0.3.0", "scipy"]

--- a/influxdata/resampler/requirements.txt
+++ b/influxdata/resampler/requirements.txt
@@ -1,2 +1,2 @@
-influxdata-plugin-utils>=0.2.0
+influxdata-plugin-utils>=0.3.0
 scipy

--- a/influxdata/signal_filter/manifest.toml
+++ b/influxdata/signal_filter/manifest.toml
@@ -2,7 +2,7 @@ manifest_schema_version = "1.3"
 
 [plugin]
 name = "signal_filter"
-version = "0.1.0"
+version = "0.2.0"
 description = "Applies streaming digital IIR filters to numeric fields"
 triggers = ["process_writes"]
 homepage = "https://www.influxdata.com/"
@@ -16,4 +16,4 @@ exclude = [
 
 [dependencies]
 database_version = ">=3.8.2"
-python = ["numpy", "scipy", "influxdata-plugin-utils>=0.2.0"]
+python = ["numpy", "scipy", "influxdata-plugin-utils>=0.3.0"]

--- a/influxdata/signal_filter/requirements.txt
+++ b/influxdata/signal_filter/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 scipy
-influxdata-plugin-utils>=0.2.0
+influxdata-plugin-utils>=0.3.0


### PR DESCRIPTION
## Summary

- require influxdata-plugin-utils>=0.3.0 for gapfill, resampler, and signal_filter
- bump each plugin version from 0.1.0 to 0.2.0
- update requirements and pinned installation examples

## Validation

- parsed all three manifests with Python tomllib
- verified dependency and plugin version consistency
- git diff --check

## Test limitation

- signal_filter unit tests were not run because numpy is not installed in the local Python environment