### PR TITLE
ci: create GitHub releases for influxdata-plugin-utils tags, and bump to 0.3.1

### DIFF
--- a/.github/workflows/publish-influxdata-plugin-utils.yml
+++ b/.github/workflows/publish-influxdata-plugin-utils.yml
@@ -28,6 +28,9 @@ jobs:
     name: Build distribution
     needs: test
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -43,6 +46,7 @@ jobs:
         run: python -m pip install --upgrade build twine packaging
 
       - name: Verify tag matches package version
+        id: meta
         shell: bash
         run: |
           set -euo pipefail
@@ -78,19 +82,77 @@ jobs:
               sys.exit(1)
 
           try:
-              tag_version = Version(expected)
               package_version = Version(actual)
           except InvalidVersion as exc:
               print(f"Invalid version: {exc}", file=sys.stderr)
               sys.exit(1)
 
-          if tag_version != package_version:
+          # Compare canonical text rather than PEP 440 equality. Version("0.3")
+          # equals Version("0.3.0"), so a loose tag would pass an equality check
+          # here, publish to PyPI as 0.3.0, and only then fail to find a
+          # "## [0.3]" changelog section that was never going to exist.
+          canonical = str(package_version)
+          if expected != canonical:
               print(
-                  f"Tag {tag!r} resolves to version {expected!r}, but package version is {actual!r}",
+                  f"Tag {tag!r} resolves to version {expected!r}, but the canonical "
+                  f"package version is {canonical!r}. Tag the release "
+                  f"{prefix}{canonical} instead.",
                   file=sys.stderr,
               )
               sys.exit(1)
-          print(f"Publishing {os.environ['PACKAGE_NAME']} {actual}")
+
+          # Every later step derives the version from this one canonical string.
+          with open(os.environ["GITHUB_OUTPUT"], "a") as handle:
+              handle.write(f"version={canonical}\n")
+              handle.write(f"prerelease={str(package_version.is_prerelease).lower()}\n")
+          print(f"Publishing {os.environ['PACKAGE_NAME']} {canonical}")
+          PY
+
+      # Generated here, before the PyPI upload, because a PyPI version cannot be
+      # republished. Finding a missing or empty changelog section after the
+      # upload would leave a version burned and no way to fix it from the tag.
+      - name: Generate release notes
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          package = os.environ["PACKAGE_NAME"]
+          changelog = Path(os.environ["PACKAGE_DIR"]) / "CHANGELOG.md"
+          text = changelog.read_text()
+
+          # End the section at the next "## " heading, the first link-definition
+          # line, or end of file. The oldest entry has no heading after it, so
+          # relying on a specific footer line would break whenever the footer
+          # is reordered or dropped.
+          pattern = rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## |^\[[^\]]+\]:|\Z)"
+          match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+          if match is None:
+              print(f"No '## [{version}]' section found in {changelog}", file=sys.stderr)
+              sys.exit(1)
+
+          body = match.group(1).strip()
+          if not body:
+              print(f"The '## [{version}]' section in {changelog} is empty", file=sys.stderr)
+              sys.exit(1)
+
+          notes = (
+              f"{body}\n\n"
+              f"## Install\n\n"
+              f"```bash\n"
+              f"pip install {package}=={version}\n"
+              f"```\n\n"
+              f"[View on PyPI](https://pypi.org/project/{package}/{version}/)\n"
+          )
+          Path(os.environ["RUNNER_TEMP"], "release-notes.md").write_text(notes)
+          print(notes)
           PY
 
       - name: Build wheel and source distribution
@@ -108,6 +170,15 @@ jobs:
           path: ${{ env.PACKAGE_DIR }}/dist/
           if-no-files-found: error
 
+      # Kept out of dist/ so the notes are never offered to PyPI or attached as
+      # a release asset.
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: ${{ env.PACKAGE_NAME }}-release-notes
+          path: ${{ runner.temp }}/release-notes.md
+          if-no-files-found: error
+
   publish:
     name: Publish distribution to PyPI
     needs: build
@@ -122,94 +193,63 @@ jobs:
       - name: Download distribution artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: influxdata-plugin-utils-dist
+          name: ${{ env.PACKAGE_NAME }}-dist
           path: dist/
 
+      # skip-existing lets a re-run get past an upload that already succeeded so
+      # it can reach the release job. Tags are immutable under the ruleset, so a
+      # re-run always builds the same commit and the same version.
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
 
   github-release:
     name: Create GitHub release
-    needs: publish
+    needs: [build, publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
       GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.build.outputs.version }}
+      PRERELEASE: ${{ needs.build.outputs.prerelease }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
       - name: Download distribution artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: influxdata-plugin-utils-dist
+          name: ${{ env.PACKAGE_NAME }}-dist
           path: dist/
 
-      - name: Extract release notes from changelog
-        shell: bash
-        run: |
-          set -euo pipefail
-          python - <<'PY'
-          import os
-          import re
-          import sys
-          from pathlib import Path
+      - name: Download release notes artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: ${{ env.PACKAGE_NAME }}-release-notes
+          path: ${{ runner.temp }}/
 
-          version = os.environ["GITHUB_REF_NAME"].removeprefix(os.environ["TAG_PREFIX"])
-          changelog = Path(os.environ["PACKAGE_DIR"]) / "CHANGELOG.md"
-          text = changelog.read_text()
-
-          # Capture everything between this version's heading and the next
-          # "## " heading (the previous release, or the link footer).
-          pattern = rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## |^\[Unreleased\]:)"
-          match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
-          if match is None:
-              print(f"No '## [{version}]' section found in {changelog}", file=sys.stderr)
-              sys.exit(1)
-
-          body = match.group(1).strip()
-          if not body:
-              print(f"The '## [{version}]' section in {changelog} is empty", file=sys.stderr)
-              sys.exit(1)
-
-          notes = (
-              f"{body}\n\n"
-              f"## Install\n\n"
-              f"```bash\n"
-              f"pip install influxdata-plugin-utils=={version}\n"
-              f"```\n\n"
-              f"[View on PyPI](https://pypi.org/project/influxdata-plugin-utils/{version}/)\n"
-          )
-          Path("/tmp/release-notes.md").write_text(notes)
-          print(notes)
-          PY
-
-      # The registry release keeps the "Latest" badge, so these are always
-      # created with --latest=false. Re-running a published tag must not fail,
-      # so an existing release is updated in place instead.
+      # The registry release keeps the "Latest" badge: moving it would repoint
+      # /releases/latest/download/* away from the registry's index.json. An
+      # existing release is updated in place so a re-run is not a hard failure.
       - name: Create or update GitHub release
         shell: bash
         run: |
           set -euo pipefail
           tag="$GITHUB_REF_NAME"
-          version="${tag#$TAG_PREFIX}"
+
+          flags=(
+            --repo "$GITHUB_REPOSITORY"
+            --title "${PACKAGE_NAME} ${VERSION}"
+            --notes-file "${RUNNER_TEMP}/release-notes.md"
+            --latest=false
+            --prerelease="$PRERELEASE"
+          )
 
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release ${tag} already exists; updating notes and assets."
-            gh release edit "$tag" \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "influxdata-plugin-utils ${version}" \
-              --notes-file /tmp/release-notes.md \
-              --latest=false
+            # --draft=false so a hand-drafted release for this tag is published
+            # rather than silently left invisible.
+            gh release edit "$tag" "${flags[@]}" --draft=false
             gh release upload "$tag" dist/* --repo "$GITHUB_REPOSITORY" --clobber
           else
-            gh release create "$tag" dist/* \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "influxdata-plugin-utils ${version}" \
-              --notes-file /tmp/release-notes.md \
-              --latest=false \
-              --verify-tag
+            gh release create "$tag" dist/* "${flags[@]}" --verify-tag
           fi

--- a/.github/workflows/publish-influxdata-plugin-utils.yml
+++ b/.github/workflows/publish-influxdata-plugin-utils.yml
@@ -127,3 +127,89 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
+  github-release:
+    name: Create GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download distribution artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: influxdata-plugin-utils-dist
+          path: dist/
+
+      - name: Extract release notes from changelog
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          version = os.environ["GITHUB_REF_NAME"].removeprefix(os.environ["TAG_PREFIX"])
+          changelog = Path(os.environ["PACKAGE_DIR"]) / "CHANGELOG.md"
+          text = changelog.read_text()
+
+          # Capture everything between this version's heading and the next
+          # "## " heading (the previous release, or the link footer).
+          pattern = rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## |^\[Unreleased\]:)"
+          match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+          if match is None:
+              print(f"No '## [{version}]' section found in {changelog}", file=sys.stderr)
+              sys.exit(1)
+
+          body = match.group(1).strip()
+          if not body:
+              print(f"The '## [{version}]' section in {changelog} is empty", file=sys.stderr)
+              sys.exit(1)
+
+          notes = (
+              f"{body}\n\n"
+              f"## Install\n\n"
+              f"```bash\n"
+              f"pip install influxdata-plugin-utils=={version}\n"
+              f"```\n\n"
+              f"[View on PyPI](https://pypi.org/project/influxdata-plugin-utils/{version}/)\n"
+          )
+          Path("/tmp/release-notes.md").write_text(notes)
+          print(notes)
+          PY
+
+      # The registry release keeps the "Latest" badge, so these are always
+      # created with --latest=false. Re-running a published tag must not fail,
+      # so an existing release is updated in place instead.
+      - name: Create or update GitHub release
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="$GITHUB_REF_NAME"
+          version="${tag#$TAG_PREFIX}"
+
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release ${tag} already exists; updating notes and assets."
+            gh release edit "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "influxdata-plugin-utils ${version}" \
+              --notes-file /tmp/release-notes.md \
+              --latest=false
+            gh release upload "$tag" dist/* --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$tag" dist/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "influxdata-plugin-utils ${version}" \
+              --notes-file /tmp/release-notes.md \
+              --latest=false \
+              --verify-tag
+          fi

--- a/influxdata-plugin-utils/CHANGELOG.md
+++ b/influxdata-plugin-utils/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-03
+
+### Changed
+
+- No functional changes. Released to exercise the tag-triggered release
+  automation added in
+  [#137](https://github.com/influxdata/influxdb3_plugins/pull/137), which
+  builds release notes from this file and publishes a GitHub release
+  alongside the PyPI upload.
+
 ## [0.3.0] - 2026-07-31
 
 ### Security
@@ -57,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `write` — `build_line`, `build_line_typed`, `add_field_with_type`,
   `write_data` (batching + retry), `BatchLines`.
 
-[Unreleased]: https://github.com/influxdata/influxdb3_plugins/compare/utils-v0.3.0...HEAD
+[Unreleased]: https://github.com/influxdata/influxdb3_plugins/compare/utils-v0.3.1...HEAD
+[0.3.1]: https://github.com/influxdata/influxdb3_plugins/compare/utils-v0.3.0...utils-v0.3.1
 [0.3.0]: https://github.com/influxdata/influxdb3_plugins/compare/utils-v0.2.0...utils-v0.3.0
 [0.2.0]: https://github.com/influxdata/influxdb3_plugins/compare/utils-v0.1.0...utils-v0.2.0
 [0.1.0]: https://github.com/influxdata/influxdb3_plugins/releases/tag/utils-v0.1.0

--- a/influxdata-plugin-utils/src/influxdata_plugin_utils/__init__.py
+++ b/influxdata-plugin-utils/src/influxdata_plugin_utils/__init__.py
@@ -8,7 +8,7 @@ Modules:
     write          - LineBuilder builders and resilient write_data
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from . import cache, config, introspection, parsing, write
 from .cache import cached


### PR DESCRIPTION
Adds a `github-release` job to `publish-influxdata-plugin-utils.yml`, so pushing a `utils-v*` tag produces a GitHub Release alongside the PyPI upload. Release notes are built from the matching `CHANGELOG.md` section; the wheel and sdist are attached as assets.

Also bumps the package to **0.3.1**. That bump has no functional changes — it exists to drive a real tag-triggered run, which is the only way to exercise the tag → PyPI → release path. It is in this PR so one review unblocks both the workflow and the release that tests it.
