### PR TITLE
ci: move actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/publish-influxdata-plugin-utils.yml
+++ b/.github/workflows/publish-influxdata-plugin-utils.yml
@@ -164,7 +164,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload distribution artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ env.PACKAGE_NAME }}-dist
           path: ${{ env.PACKAGE_DIR }}/dist/
@@ -173,7 +173,7 @@ jobs:
       # Kept out of dist/ so the notes are never offered to PyPI or attached as
       # a release asset.
       - name: Upload release notes artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ env.PACKAGE_NAME }}-release-notes
           path: ${{ runner.temp }}/release-notes.md
@@ -191,7 +191,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ env.PACKAGE_NAME }}-dist
           path: dist/
@@ -216,13 +216,13 @@ jobs:
       PRERELEASE: ${{ needs.build.outputs.prerelease }}
     steps:
       - name: Download distribution artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ env.PACKAGE_NAME }}-dist
           path: dist/
 
       - name: Download release notes artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ env.PACKAGE_NAME }}-release-notes
           path: ${{ runner.temp }}/

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Resolve SDK version
         shell: bash

--- a/.github/workflows/remind-sync-docs.yml
+++ b/.github/workflows/remind-sync-docs.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2  # Need previous commit to detect changes
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create sync reminder comment
         if: steps.detect-changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.ISSUES_READ_WRITE_TOKEN }}
           script: |

--- a/.github/workflows/validate-registry-plugins.yml
+++ b/.github/workflows/validate-registry-plugins.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

The 0.3.1 release run carried this annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/upload-artifact@330a01c`

Auditing every action in the repo turned up four on Node 20, not one. Each is bumped to the **earliest** version that declares `runs.using: node24`:

| Action | Before | After | SHA |
|---|---|---|---|
| `actions/upload-artifact` | v5.0.0 | **v6.0.0** | `b7c566a` |
| `actions/download-artifact` | v6.0.0 | **v7.0.0** | `37930b1` |
| `actions/github-script` | v7 *(unpinned)* | **v8.0.0** | `ed59741` |
| `actions/checkout` | v4 *(unpinned)* | **v6.0.3** | `df4cb1c` |

## Why the earliest Node 24 version, not the latest

These are runtime-only bumps with no API changes. The next majors carry real behaviour changes that aren't needed to clear the deprecation:

- **upload-artifact v7** — ESM migration; direct uploads where `name` is ignored.
- **download-artifact v8** — ESM; **digest mismatches now fail instead of warning**; unzip behaviour depends on `Content-Type`.
- **github-script v9** — `require('@actions/github')` stops working; `getOctokit` becomes an injected parameter.

The github-script v9 breaks don't actually affect the one script here, which only calls `github.rest.repos.createCommitComment`. It's held back for consistency with the others rather than out of necessity. Adopting the newer majors is a reasonable follow-up, just not mixed into a deprecation fix — especially with download-artifact v8 turning digest mismatches into hard failures.

## Unreachable checkout SHA

Three `actions/checkout` uses pinned SHA `9f698171…`, commented `# v6.0.3`. That commit is **not reachable from any ref in actions/checkout**:

```
GET /repos/actions/checkout/commits/9f698171…      -> 422 No commit found
GET /repos/actions/checkout/git/commits/9f698171…  -> 404 Not Found
raw.githubusercontent.com/.../9f698171…/action.yml -> 404
codeload.github.com/.../tar.gz/9f698171…           -> 200 OK
```

Only codeload resolves it, which is why the runner fetches it fine while every audit path fails. Practical consequences: Dependabot and Renovate can't track it, and it can't be reviewed upstream.

It is **not** malicious. Its `dist/index.js` is byte-identical to the real v6.0.3 (`df4cb1c`), verified by SHA-256 against v5.0.0, v5.0.1, v5.1.0, and v6.0.3. (The `package.json` inside reads `5.0.0`, but so does real v6.0.3 — upstream doesn't bump it.) It was also already Node 24, so it was never part of the deprecation.

Repointed to `df4cb1c` so every checkout in the repo uses the same verified, reachable SHA.

## Verification

Each resulting pin was checked to resolve to a reachable commit, to match the version in its trailing comment, and to declare `node24`:

```
actions/checkout          v6.0.3  node24  reachable=yes  tag-matches-sha=yes
actions/download-artifact v7.0.0  node24  reachable=yes  tag-matches-sha=yes
actions/github-script     v8.0.0  node24  reachable=yes  tag-matches-sha=yes
actions/setup-python      v6.3.0  node24  reachable=yes  tag-matches-sha=yes
actions/upload-artifact   v6.0.0  node24  reachable=yes  tag-matches-sha=yes
```

No unpinned actions remain. `pypa/gh-action-pypi-publish` is a Docker action with no Node runtime, so it is unaffected. All five workflow files parse.

The upload/download pairing matters for the release workflow, which uploads dists and notes in `build` and downloads them in two later jobs. upload-artifact v6 and download-artifact v7 are the matched Node 24 releases on the same v4 artifact backend.

Not verified here: these run for real only on the next tag push or registry publish. The changes are pure SHA swaps, so the risk is low, but nothing in this PR exercises the artifact round-trip end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)