### PR TITLE
Adding a new plugin: Earthquake Plugin, ingests earthquake events and writes normalized points for dashboards and alerting

### DIFF
--- a/influxdata/earthquake_sampler/README.md
+++ b/influxdata/earthquake_sampler/README.md
@@ -1,112 +1,249 @@
 # InfluxDB 3 Earthquake Sampler Plugin
 
-A scheduled InfluxDB 3 Processing Engine plugin that ingests earthquake events and writes normalized points for dashboards and alerting.
+⚡ scheduled 🏷️ earthquake, geoscience, sample-data, monitoring, alerting 🔧 InfluxDB 3 Core, InfluxDB 3 Enterprise
 
-## What this plugin does
+## Description
 
-On each scheduled run, the plugin:
+The Earthquake Sampler Plugin ingests earthquake events from the USGS GeoJSON feeds on a schedule and writes normalized points for dashboards and alerting. It can also read from a custom JSON endpoint or from an existing InfluxDB table, and optionally writes directly into an existing canonical `quake` table using that table's column names (`write_quake_schema=true`). Events are deduplicated with a per-event update-marker cache, so reruns only write new or updated earthquakes.
 
-- reads earthquake data from one of two source modes:
-  - `source_type=http`:
-    - USGS GeoJSON feeds (`feed=all_hour`, `significant_day`, `4.5_week`, etc.), or
-    - a custom JSON endpoint (`source_url=...`) with parser `source_format=usgs_geojson|flat_json`
-  - `source_type=influxdb_table`:
-    - reads rows directly from an existing InfluxDB table (for example `usgs.quake`)
-- normalizes each event into a common schema
-- filters by minimum magnitude (`min_magnitude`)
-- enforces per-run cap (`max_events`)
-- deduplicates events using cached update markers (`skip_unchanged=true`)
-- writes normalized earthquake event rows to the destination measurement (default `earthquakes`)
-- can write directly into an existing canonical `quake` table with its original column names and types (`write_quake_schema=true`)
+- **Zero authentication**: USGS feeds require no API keys or signup
+- **Two source modes**: HTTP (USGS or custom JSON) and `influxdb_table` (transform rows from an existing table)
+- **Per-event deduplication**: update markers are cached per event id; updated events are re-written, unchanged events are skipped
+- **Canonical quake schema**: optional direct writes into an existing `quake` table
 
-## Files
+## Configuration
 
-- `earthquake_sampler.py` - plugin source code
+Plugin parameters may be specified as key-value pairs in the `--trigger-arguments` flag (CLI) or in the `trigger_arguments` field (API) when creating a trigger. All parameters are optional; invalid values abort the run with an error log rather than silently falling back to defaults.
 
-## Key trigger arguments
+### Plugin metadata
 
-- `source_type`: `http` (default) or `influxdb_table`
-- `feed`: USGS feed key when using HTTP mode
-- `source_url`: custom URL when using HTTP mode
-- `source_format`: `usgs_geojson` or `flat_json`
-- `source_table`: source table for `influxdb_table` mode (default `quake`)
-- `source_query`: optional SQL override for table mode
-- `lookback_minutes`: table query lookback window (default `15`)
-- `measurement`: destination measurement (default `earthquakes`)
-- `write_quake_schema`: write only the canonical `quake` columns (`depth`, `depthError`, `dmin`, `gap`, `horizontalError`, `id`, `latitude`, `locationSource`, `longitude`, `mag`, `magError`, `magNst`, `magSource`, `magType`, `net`, `nst`, `place`, `rms`, `status`, `time`, and `type`). Use with `measurement=quake`. Note: `depthError`, `horizontalError`, `magError`, `magNst`, `locationSource`, and `magSource` exist only in USGS CSV feeds, not GeoJSON, so they are written only when a `flat_json` or `influxdb_table` source supplies them.
+This plugin includes a JSON metadata schema in its docstring that defines supported trigger types and configuration parameters. This metadata enables the [InfluxDB 3 Explorer](https://docs.influxdata.com/influxdb3/explorer/) UI to display and configure the plugin.
 
-- `min_magnitude`: optional minimum magnitude filter; when omitted, nothing is filtered (USGS feeds include negative-magnitude microseisms)
-- `max_events`: max events processed per run
-- `skip_unchanged`: skip unchanged events based on cached marker
-- `use_event_timestamp`: write event timestamp vs trigger time
+### Data selection parameters
 
-## Install / deploy
+| Parameter          | Type    | Default        | Description                                                                                                                                                  |
+|--------------------|---------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `feed`             | string  | all_hour       | USGS GeoJSON feed key: `all`, `significant`, `4.5`, `2.5`, or `1.0` combined with `_hour`, `_day`, `_week`, or `_month` (for example `significant_day`)       |
+| `source_type`      | string  | http           | Data source type: `http` fetches JSON from `source_url` or `feed`; `influxdb_table` queries an existing table in the trigger database                        |
+| `source_url`       | string  | none           | Custom source URL (`http` or `https` only). When provided, overrides `feed` and uses `source_format` parsing                                                 |
+| `source_format`    | string  | usgs_geojson   | Source parser for HTTP mode: `usgs_geojson` or `flat_json` (for records like `{id, latitude, longitude, mag, time, ...}`)                                    |
+| `source_table`     | string  | quake          | Source table name when `source_type=influxdb_table`                                                                                                          |
+| `source_query`     | string  | none           | Optional SQL override for `influxdb_table` mode; disables watermark paging                                                                                    |
+| `lookback_minutes` | integer | 15             | Initial lookback window for `influxdb_table` mode. Later runs page forward from the cached fetch watermark while `skip_unchanged=true`                        |
 
-### Option A: Generic InfluxDB 3 trigger create (from a node with `influxdb3` CLI)
+### Optional parameters
 
-1) Place plugin file where CLI can read it:
+| Parameter             | Type    | Default                         | Description                                                                                                                                                  |
+|-----------------------|---------|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `measurement`         | string  | earthquakes                     | Destination measurement name                                                                                                                                 |
+| `write_quake_schema`  | boolean | false                           | Write events using the canonical `quake` table's column names; no tags or normalized-only columns are written. Use with `measurement=quake`                  |
+| `min_magnitude`       | float   | none                            | Optional minimum magnitude. When omitted, nothing is filtered (USGS feeds include negative-magnitude microseisms and events without a magnitude)             |
+| `max_events`          | integer | 250                             | Maximum events written per run, applied after filtering. Events deferred by the cap remain uncached and are written on a later run                            |
+| `use_event_timestamp` | boolean | true                            | Use the event time as the point timestamp; `false` uses the trigger execution time. Ignored (forced `true`) when `write_quake_schema=true`                   |
+| `skip_unchanged`      | boolean | true                            | Skip events whose update marker is not newer than the last written copy of the same event. Events without an id are always written                            |
+| `user_agent`          | string  | InfluxDB3-Earthquake-Plugin/1.0 | Custom User-Agent header for API requests                                                                                                                    |
+| `enable_full_logging` | boolean | false                           | When `true`, full exception messages are logged. When `false` (default), only exception types are logged                                                     |
 
-- `earthquake_sampler.py`
+## Schema requirements
 
-2) Create a scheduled trigger that fetches the USGS GeoJSON `all_hour` feed and writes it directly to `usgs.quake`:
+`write_quake_schema=true` targets an existing `quake` table with the USGS CSV column layout (`depth`, `dmin`, `gap`, `id`, `latitude`, `longitude`, `mag`, `magType`, `net`, `nst`, `place`, `rms`, `status`, `time`, `type`, and the CSV-only columns below).
+
+- All numeric columns (including `nst` and `magNst`) are written as float64. This matches quake tables created by CSV import, where numeric columns containing blanks are inferred as doubles. If your existing table stores these columns as int64, the writes are rejected with a type conflict.
+- `depthError`, `horizontalError`, `magError`, `magNst`, `locationSource`, and `magSource` exist only in USGS CSV feeds, not GeoJSON, so they are written only when a `flat_json` or `influxdb_table` source supplies them.
+- Quake-schema rows carry no tags, so point identity rests entirely on the timestamp. USGS supplies millisecond-precision times; the plugin fills the unused sub-millisecond bits with a stable per-event offset so two earthquakes in the same millisecond do not overwrite each other. Millisecond-level time is unchanged.
+
+## Software requirements
+
+- **InfluxDB 3 Core/Enterprise**: 3.8.2 or later (the plugin writes with `write_sync`), with the Processing Engine enabled
+- **Python packages**: No additional packages required (uses the Python standard library only)
+- **Network access**: Outbound HTTPS access to `earthquake.usgs.gov` (HTTP mode)
+
+### Installation steps
+
+1. Start InfluxDB 3 with the Processing Engine enabled (`--plugin-dir /path/to/plugins`):
+
+   ```bash
+   influxdb3 serve \
+     --node-id node0 \
+     --object-store file \
+     --data-dir ~/.influxdb3 \
+     --plugin-dir ~/.plugins
+   ```
+
+2. No additional Python packages are required for this plugin.
+
+## Trigger setup
+
+### Scheduled trigger
+
+Create a trigger that ingests the USGS `all_hour` feed every two minutes:
 
 ```bash
 influxdb3 create trigger \
-  --database usgs \
-  --path ./earthquake_sampler.py \
-  --upload \
+  --database quakes \
+  --path "gh:influxdata/earthquake_sampler/earthquake_sampler.py" \
   --trigger-spec "every:2m" \
-  --trigger-arguments "source_type=http,feed=all_hour,measurement=quake,write_quake_schema=true,max_events=500,skip_unchanged=true,use_event_timestamp=true" \
-  usgs_to_quake
+  earthquake_sampler_trigger
+
+# Enable the trigger
+influxdb3 enable trigger --database quakes earthquake_sampler_trigger
 ```
 
-### Option B: Local Kubernetes install (namespace `influxdb3`, processor pod)
+## Example usage
 
-This matches a processor pod named `db3-influxdb3-enterprise-processor-0`.
+### Example 1: Normalized earthquake ingestion
 
-1) Copy plugin to processor pod:
+Ingest the daily feed into the normalized `earthquakes` measurement:
 
 ```bash
-kubectl -n influxdb3 cp ./earthquake_sampler.py db3-influxdb3-enterprise-processor-0:/tmp/earthquake_sampler.py
+# Create the trigger
+influxdb3 create trigger \
+  --database quakes \
+  --path "gh:influxdata/earthquake_sampler/earthquake_sampler.py" \
+  --trigger-spec "every:5m" \
+  --trigger-arguments "feed=all_day" \
+  earthquakes_all_day
+
+# Enable the trigger
+influxdb3 enable trigger --database quakes earthquakes_all_day
+
+# Query events (after a few minutes)
+influxdb3 query \
+  --database quakes \
+  "SELECT event_id, magnitude, place, latitude, longitude, depth_km, time FROM earthquakes ORDER BY time DESC LIMIT 5"
 ```
 
-2) Get admin token from secret and create trigger in DB `usgs`:
+### Expected output
+
+ event_id   | magnitude | place                        | latitude | longitude | depth_km | time
+ -----------|-----------|------------------------------|----------|-----------|----------|-----
+ us7000abcd | 4.6       | 100 km SSW of Sand Point, AK | 54.5     | -161.2    | 32.4     | 2026-08-21T17:58:12.421Z
+ ak0261abcd | 1.4       | 12 km NNE of Palmer, AK      | 61.7     | -148.9    | 27.9     | 2026-08-21T17:55:03.118Z
+ nc75abcdef | 0.9       | 8 km WNW of Cobb, CA         | 38.8     | -122.8    | 1.6      | 2026-08-21T17:51:47.902Z
+
+### Example 2: Write directly into an existing quake table
+
+Write USGS events into an existing `quake` table using its original column names (see [Schema requirements](#schema-requirements)):
 
 ```bash
-TOKEN=$(kubectl -n influxdb3 get secret influxdb3-admin-token -o jsonpath='{.data.TOKEN}' | base64 -d)
-
-kubectl -n influxdb3 exec db3-influxdb3-enterprise-processor-0 -- sh -lc "
 influxdb3 create trigger \
   --database usgs \
-  --token '$TOKEN' \
-  --host http://127.0.0.1:8181 \
-  --node-spec 'nodes:db3-influxdb3-enterprise-processor-0' \
-  --path /tmp/earthquake_sampler.py \
-  --upload \
-  --trigger-spec 'every:2m' \
-  --trigger-arguments 'source_type=http,feed=all_hour,measurement=quake,write_quake_schema=true,max_events=500,skip_unchanged=true,use_event_timestamp=true' \
+  --path "gh:influxdata/earthquake_sampler/earthquake_sampler.py" \
+  --trigger-spec "every:2m" \
+  --trigger-arguments "feed=all_hour,measurement=quake,write_quake_schema=true" \
   usgs_to_quake
-"
 ```
 
-## Validate plugin output
+### Example 3: Transform rows from an existing table
+
+Read rows from an existing `quake` table and write them as normalized events. The plugin pages forward from a cached fetch watermark, so each run picks up where the previous one stopped:
 
 ```bash
-# Trigger metadata
-influxdb3 query --database usgs "SELECT trigger_name, trigger_specification, disabled FROM system.processing_engine_triggers"
-
-# Plugin logs
-influxdb3 query --database usgs "SELECT time, trigger_name, log_level, log_text FROM system.processing_engine_logs WHERE trigger_name='usgs_to_quake' ORDER BY time DESC LIMIT 20"
-
-# Event data
-influxdb3 query --database usgs "SELECT id, mag, place, latitude, longitude, depth, time FROM quake ORDER BY time DESC LIMIT 20"
+influxdb3 create trigger \
+  --database usgs \
+  --path "gh:influxdata/earthquake_sampler/earthquake_sampler.py" \
+  --trigger-spec "every:1m" \
+  --trigger-arguments "source_type=influxdb_table,source_table=quake,measurement=earthquakes,lookback_minutes=60" \
+  quake_to_earthquakes
 ```
 
-## Notes
+### Example 4: Magnitude filtering
 
-- This repo is intentionally minimal: docs + plugin code.
-- No extra Python dependencies are required in plugin code (stdlib only).
-- The plugin does not create or write an `earthquake_plugin_stats` table.
-- `write_quake_schema=true` is intended for an existing `quake` table with the documented schema; it never writes tags or normalized-only columns such as `event_id` or `magnitude`.
-- In `write_quake_schema=true` mode, all numeric columns (including `nst` and `magNst`) are written as float64. This matches quake tables created by CSV import, where numeric columns containing blanks are inferred as doubles. If your existing table stores these columns as int64, the writes will be rejected with a type conflict.
-- Because quake-schema rows carry no tags, point identity rests entirely on the timestamp. USGS supplies millisecond-precision times, so the plugin fills the unused sub-millisecond bits with a stable per-event offset to keep two earthquakes in the same millisecond from overwriting each other; millisecond-level time is unchanged. For the same reason, `use_event_timestamp=false` is ignored in this mode.
+Only ingest events at or above magnitude 2.5:
+
+```bash
+influxdb3 create trigger \
+  --database quakes \
+  --path "gh:influxdata/earthquake_sampler/earthquake_sampler.py" \
+  --trigger-spec "every:5m" \
+  --trigger-arguments "feed=all_day,min_magnitude=2.5" \
+  earthquakes_m25
+```
+
+## Code overview
+
+### Files
+
+- `earthquake_sampler.py`: The main plugin code containing the scheduled handler for earthquake ingestion
+
+### Logging
+
+Logs are stored in the trigger's database in the `system.processing_engine_logs` table. To view logs:
+
+```bash
+influxdb3 query --database YOUR_DATABASE "SELECT event_time, log_level, log_text FROM system.processing_engine_logs WHERE trigger_name = 'earthquake_sampler_trigger' ORDER BY event_time DESC LIMIT 20"
+```
+
+Log lines are prefixed with a per-run task id. Logged source names strip URL credentials/query strings and truncate custom SQL.
+
+### Main functions
+
+#### `process_scheduled_call(influxdb3_local, call_time, args)`
+
+Handles a scheduled run end to end: validates configuration (aborting with an error on invalid values), fetches events from the configured source, normalizes and filters them, deduplicates against the per-event marker cache, and writes points with `write_sync` so write errors surface during the run.
+
+#### `_fetch_payload(url, user_agent)` / `_fetch_table_rows(...)`
+
+HTTP fetching (scheme-validated, `http`/`https` only) and table reading. Table reads page oldest-first from the cached fetch watermark (`WHERE time > watermark ORDER BY time ASC LIMIT max_events`), falling back to the `lookback_minutes` window on the first run.
+
+#### `_normalize_usgs_feature(feature)` / `_normalize_flat_event(item)`
+
+Normalize a USGS GeoJSON feature or a flat JSON/table record into the common internal event shape. Timestamps of unknown shape (ISO strings, epoch seconds/ms/us/ns) are coerced by magnitude.
+
+#### `_write_event(...)` / `_write_quake_event(...)`
+
+Build and write a point in the normalized schema (tags: `event_type`, `status`, `alert`, `net`, `mag_type`; `event_id` is a string field to avoid unbounded series cardinality) or in the canonical quake schema (no tags). Millisecond-aligned timestamps get a stable per-event sub-millisecond offset so same-millisecond events stay distinct.
+
+## Troubleshooting
+
+### Common issues
+
+#### Issue: No data appearing
+
+**Solution**: Check trigger status, review plugin logs, and verify network connectivity:
+
+```bash
+# Check trigger status
+influxdb3 show summary --database quakes --token YOUR_TOKEN
+
+# Check plugin logs
+influxdb3 query --database quakes "SELECT event_time, log_level, log_text FROM system.processing_engine_logs WHERE log_text LIKE '%Earthquake%' ORDER BY event_time DESC LIMIT 10"
+
+# Verify the feed is reachable
+curl -H "User-Agent: test" https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson
+```
+
+#### Issue: `Invalid configuration` error in logs
+
+**Solution**: A trigger argument has an invalid value (unknown `feed` key, non-numeric `min_magnitude`, unrecognized boolean, and so on). The error message names the argument; the run aborts rather than proceeding with a silent fallback.
+
+#### Issue: Log summary shows `written=0` with a nonzero `skipped` count
+
+**Solution**: This is normal steady-state behavior: `skip_unchanged=true` skips events already written at their current update marker. New and updated events are still written. Set `skip_unchanged=false` to re-write everything the source returns.
+
+#### Issue: Field type conflict when writing with `write_quake_schema=true`
+
+**Solution**: The plugin writes all numeric quake columns as float64 (see [Schema requirements](#schema-requirements)). If your existing table stores `nst` or `magNst` as int64, rename the destination via `measurement` or recreate the table with float64 columns.
+
+#### Issue: Table mode does not re-read older rows
+
+**Solution**: With `skip_unchanged=true`, table reads page forward from the cached fetch watermark and do not revisit rows behind it. Set `skip_unchanged=false` to re-read the full `lookback_minutes` window, or provide an explicit `source_query`.
+
+### Debugging tips
+
+1. **Check trigger status**:
+   ```bash
+   influxdb3 show summary --database quakes --token YOUR_TOKEN
+   ```
+
+2. **Enable/Disable trigger**:
+   ```bash
+   influxdb3 disable trigger earthquake_sampler_trigger --database quakes --token YOUR_TOKEN
+   influxdb3 enable trigger earthquake_sampler_trigger --database quakes --token YOUR_TOKEN
+   ```
+
+3. **Enable full exception logging temporarily**: add `enable_full_logging=true` to the trigger arguments.
+
+## Questions/Comments
+
+For additional support, see the [Support section](../README.md#support).

--- a/influxdata/earthquake_sampler/README.md
+++ b/influxdata/earthquake_sampler/README.md
@@ -21,15 +21,15 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 
 ### Data selection parameters
 
-| Parameter          | Type    | Default        | Description                                                                                                                                                  |
-|--------------------|---------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `feed`             | string  | all_hour       | USGS GeoJSON feed key: `all`, `significant`, `4.5`, `2.5`, or `1.0` combined with `_hour`, `_day`, `_week`, or `_month` (for example `significant_day`)       |
-| `source_type`      | string  | http           | Data source type: `http` fetches JSON from `source_url` or `feed`; `influxdb_table` queries an existing table in the trigger database                        |
-| `source_url`       | string  | none           | Custom source URL (`http` or `https` only). When provided, overrides `feed` and uses `source_format` parsing                                                 |
-| `source_format`    | string  | usgs_geojson   | Source parser for HTTP mode: `usgs_geojson` or `flat_json` (for records like `{id, latitude, longitude, mag, time, ...}`)                                    |
-| `source_table`     | string  | quake          | Source table name when `source_type=influxdb_table`                                                                                                          |
-| `source_query`     | string  | none           | Optional SQL override for `influxdb_table` mode; disables watermark paging                                                                                    |
-| `lookback_minutes` | integer | 15             | Initial lookback window for `influxdb_table` mode. Later runs page forward from the cached fetch watermark while `skip_unchanged=true`                        |
+| Parameter          | Type    | Default        | Description                                                                                                                                                                                                           |
+|--------------------|---------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `feed`             | string  | all_hour       | USGS GeoJSON feed key: `all`, `significant`, `4.5`, `2.5`, or `1.0` combined with `_hour`, `_day`, `_week`, or `_month` (for example `significant_day`)                                                               |
+| `source_type`      | string  | http           | Data source type: `http` fetches JSON from `source_url` or `feed`; `influxdb_table` queries an existing table in the trigger database                                                                                 |
+| `source_url`       | string  | none           | Custom source URL (`http` or `https` only). When provided, overrides `feed` and uses `source_format` parsing                                                                                                          |
+| `source_format`    | string  | usgs_geojson   | Source parser for HTTP mode: `usgs_geojson` or `flat_json` (for records like `{id, latitude, longitude, mag, time, ...}`)                                                                                             |
+| `source_table`     | string  | quake          | Source table name when `source_type=influxdb_table`                                                                                                                                                                   |
+| `source_query`     | string  | none           | Optional SQL override for `influxdb_table` mode; disables watermark paging and the source-table existence check. A query containing commas must come from a TOML file — see [TOML configuration](#toml-configuration) |
+| `lookback_minutes` | integer | 15             | Initial lookback window for `influxdb_table` mode. Later runs page forward from the cached fetch watermark while `skip_unchanged=true`                                                                                |
 
 ### Optional parameters
 
@@ -43,6 +43,42 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 | `skip_unchanged`      | boolean | true                            | Skip events whose update marker is not newer than the last written copy of the same event. Events without an id are always written                            |
 | `user_agent`          | string  | InfluxDB3-Earthquake-Plugin/1.0 | Custom User-Agent header for API requests                                                                                                                    |
 | `enable_full_logging` | boolean | false                           | When `true`, full exception messages are logged. When `false` (default), only exception types are logged                                                     |
+| `config_file_path`    | string  | none                            | Path to a TOML configuration file, relative to the plugin directory. See [TOML configuration](#toml-configuration)                                            |
+
+### TOML configuration
+
+Trigger arguments are a comma-separated `key=value` list, so a value that itself contains a comma — most notably `source_query` — cannot be passed inline. Put those parameters in a TOML file instead and point `config_file_path` at it. The path is resolved relative to the plugin directory (`PLUGIN_DIR`, `INFLUXDB3_PLUGIN_DIR`, or the processing-engine virtualenv).
+
+Values in the file override the inline trigger arguments. A file that is missing, malformed, or fails validation is reported in the logs and skipped, and the run continues with the inline arguments; a path that does not end in `.toml` is rejected the same way.
+
+`earthquake_sampler_config_scheduler.toml` ships alongside the plugin with every
+parameter documented and commented out. Copy it into your plugin directory and
+uncomment what you need:
+
+```toml
+measurement = "earthquakes"
+feed = "all_day"
+min_magnitude = 2.5
+max_events = 500
+skip_unchanged = true
+
+# A query containing commas is only expressible here, not in --trigger-arguments.
+# Use a single-quoted TOML string when column names need double quotes.
+source_type = "influxdb_table"
+source_table = "quake"
+source_query = 'SELECT time, id, mag, depth, "magType", net, updated FROM quake ORDER BY time DESC LIMIT 500'
+```
+
+```bash
+influxdb3 create trigger \
+  --database quakes \
+  --path "gh:influxdata/earthquake_sampler/earthquake_sampler.py" \
+  --trigger-spec "every:5m" \
+  --trigger-arguments "config_file_path=earthquake_sampler_config_scheduler.toml" \
+  earthquakes_from_toml
+```
+
+Types are native in TOML: `min_magnitude = 2.5` and `skip_unchanged = true` need no quoting, unlike the string values that inline arguments always deliver.
 
 ## Schema requirements
 
@@ -55,7 +91,7 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
 ## Software requirements
 
 - **InfluxDB 3 Core/Enterprise**: 3.8.2 or later (the plugin writes with `write_sync`), with the Processing Engine enabled
-- **Python packages**: No additional packages required (uses the Python standard library only)
+- **Python packages**: `influxdata-plugin-utils>=0.3.0`
 - **Network access**: Outbound HTTPS access to `earthquake.usgs.gov` (HTTP mode)
 
 ### Installation steps
@@ -70,7 +106,11 @@ This plugin includes a JSON metadata schema in its docstring that defines suppor
      --plugin-dir ~/.plugins
    ```
 
-2. No additional Python packages are required for this plugin.
+2. Install the required Python package:
+
+   ```bash
+   influxdb3 install package influxdata-plugin-utils
+   ```
 
 ## Trigger setup
 
@@ -165,6 +205,8 @@ influxdb3 create trigger \
 ### Files
 
 - `earthquake_sampler.py`: The main plugin code containing the scheduled handler for earthquake ingestion
+- `requirements.txt`: Python dependencies (`influxdata-plugin-utils`, used for configuration loading, validation, and writes)
+- `earthquake_sampler_config_scheduler.toml`: Example TOML configuration with every parameter documented
 
 ### Logging
 
@@ -192,7 +234,7 @@ Normalize a USGS GeoJSON feature or a flat JSON/table record into the common int
 
 #### `_write_event(...)` / `_write_quake_event(...)`
 
-Build and write a point in the normalized schema (tags: `event_type`, `status`, `alert`, `net`, `mag_type`; `event_id` is a string field to avoid unbounded series cardinality) or in the canonical quake schema (no tags). Millisecond-aligned timestamps get a stable per-event sub-millisecond offset so same-millisecond events stay distinct.
+Build and write a point in the normalized schema (tags: `event_type`, `status`, `alert`, `net`, `mag_type`; `event_id` is a string field to avoid unbounded series cardinality) or in the canonical quake schema (no tags). Fields the source does not supply are left out of the point rather than written as empty values, and an event with no usable field at all is skipped and logged. Millisecond-aligned timestamps get a stable per-event sub-millisecond offset so same-millisecond events stay distinct.
 
 ## Troubleshooting
 
@@ -215,7 +257,11 @@ curl -H "User-Agent: test" https://earthquake.usgs.gov/earthquakes/feed/v1.0/sum
 
 #### Issue: `Invalid configuration` error in logs
 
-**Solution**: A trigger argument has an invalid value (unknown `feed` key, non-numeric `min_magnitude`, unrecognized boolean, and so on). The error message names the argument; the run aborts rather than proceeding with a silent fallback.
+**Solution**: A trigger argument has an invalid value (unknown `feed` key, non-numeric `min_magnitude`, unrecognized boolean, `max_events` below 1, and so on). The message quotes the offending value; the run aborts rather than proceeding with a silent fallback. Booleans accept `true/false`, `yes/no`, `on/off`, and `1/0`.
+
+#### Issue: `Source table ... not found in the trigger database`
+
+**Solution**: `source_type=influxdb_table` checks that `source_table` exists before querying it. Verify the name with `influxdb3 query --database YOUR_DATABASE "SHOW TABLES"`, or supply an explicit `source_query`, which bypasses the check.
 
 #### Issue: Log summary shows `written=0` with a nonzero `skipped` count
 

--- a/influxdata/earthquake_sampler/README.md
+++ b/influxdata/earthquake_sampler/README.md
@@ -35,7 +35,7 @@ On each scheduled run, the plugin:
 - `measurement`: destination measurement (default `earthquakes`)
 - `write_quake_schema`: write only the canonical `quake` columns (`depth`, `depthError`, `dmin`, `gap`, `horizontalError`, `id`, `latitude`, `locationSource`, `longitude`, `mag`, `magError`, `magNst`, `magSource`, `magType`, `net`, `nst`, `place`, `rms`, `status`, `time`, and `type`). Use with `measurement=quake`.
 
-- `min_magnitude`: minimum magnitude filter
+- `min_magnitude`: optional minimum magnitude filter; when omitted, nothing is filtered (USGS feeds include negative-magnitude microseisms)
 - `max_events`: max events processed per run
 - `skip_unchanged`: skip unchanged events based on cached marker
 - `use_event_timestamp`: write event timestamp vs trigger time
@@ -56,7 +56,7 @@ influxdb3 create trigger \
   --path ./earthquake_sampler.py \
   --upload \
   --trigger-spec "every:2m" \
-  --trigger-arguments "source_type=http,feed=all_hour,measurement=quake,write_quake_schema=true,max_events=500,min_magnitude=0.0,skip_unchanged=true,use_event_timestamp=true" \
+  --trigger-arguments "source_type=http,feed=all_hour,measurement=quake,write_quake_schema=true,max_events=500,skip_unchanged=true,use_event_timestamp=true" \
   usgs_to_quake
 ```
 
@@ -84,7 +84,7 @@ influxdb3 create trigger \
   --path /tmp/earthquake_sampler.py \
   --upload \
   --trigger-spec 'every:2m' \
-  --trigger-arguments 'source_type=http,feed=all_hour,measurement=quake,write_quake_schema=true,max_events=500,min_magnitude=0.0,skip_unchanged=true,use_event_timestamp=true' \
+  --trigger-arguments 'source_type=http,feed=all_hour,measurement=quake,write_quake_schema=true,max_events=500,skip_unchanged=true,use_event_timestamp=true' \
   usgs_to_quake
 "
 ```

--- a/influxdata/earthquake_sampler/README.md
+++ b/influxdata/earthquake_sampler/README.md
@@ -108,4 +108,5 @@ influxdb3 query --database usgs "SELECT id, mag, place, latitude, longitude, dep
 - No extra Python dependencies are required in plugin code (stdlib only).
 - The plugin does not create or write an `earthquake_plugin_stats` table.
 - `write_quake_schema=true` is intended for an existing `quake` table with the documented schema; it never writes tags or normalized-only columns such as `event_id` or `magnitude`.
+- In `write_quake_schema=true` mode, all numeric columns (including `nst` and `magNst`) are written as float64. This matches quake tables created by CSV import, where numeric columns containing blanks are inferred as doubles. If your existing table stores these columns as int64, the writes will be rejected with a type conflict.
 - Because quake-schema rows carry no tags, point identity rests entirely on the timestamp. USGS supplies millisecond-precision times, so the plugin fills the unused sub-millisecond bits with a stable per-event offset to keep two earthquakes in the same millisecond from overwriting each other; millisecond-level time is unchanged. For the same reason, `use_event_timestamp=false` is ignored in this mode.

--- a/influxdata/earthquake_sampler/README.md
+++ b/influxdata/earthquake_sampler/README.md
@@ -108,3 +108,4 @@ influxdb3 query --database usgs "SELECT id, mag, place, latitude, longitude, dep
 - No extra Python dependencies are required in plugin code (stdlib only).
 - The plugin does not create or write an `earthquake_plugin_stats` table.
 - `write_quake_schema=true` is intended for an existing `quake` table with the documented schema; it never writes tags or normalized-only columns such as `event_id` or `magnitude`.
+- Because quake-schema rows carry no tags, point identity rests entirely on the timestamp. USGS supplies millisecond-precision times, so the plugin fills the unused sub-millisecond bits with a stable per-event offset to keep two earthquakes in the same millisecond from overwriting each other; millisecond-level time is unchanged. For the same reason, `use_event_timestamp=false` is ignored in this mode.

--- a/influxdata/earthquake_sampler/README.md
+++ b/influxdata/earthquake_sampler/README.md
@@ -1,0 +1,110 @@
+# InfluxDB 3 Earthquake Sampler Plugin
+
+A scheduled InfluxDB 3 Processing Engine plugin that ingests earthquake events and writes normalized points for dashboards and alerting.
+
+## What this plugin does
+
+On each scheduled run, the plugin:
+
+- reads earthquake data from one of two source modes:
+  - `source_type=http`:
+    - USGS GeoJSON feeds (`feed=all_hour`, `significant_day`, `4.5_week`, etc.), or
+    - a custom JSON endpoint (`source_url=...`) with parser `source_format=usgs_geojson|flat_json`
+  - `source_type=influxdb_table`:
+    - reads rows directly from an existing InfluxDB table (for example `usgs.quake`)
+- normalizes each event into a common schema
+- filters by minimum magnitude (`min_magnitude`)
+- enforces per-run cap (`max_events`)
+- deduplicates events using cached update markers (`skip_unchanged=true`)
+- writes normalized earthquake event rows to the destination measurement (default `earthquakes`)
+- can write directly into an existing canonical `quake` table with its original column names and types (`write_quake_schema=true`)
+
+## Files
+
+- `earthquake_sampler.py` - plugin source code
+
+## Key trigger arguments
+
+- `source_type`: `http` (default) or `influxdb_table`
+- `feed`: USGS feed key when using HTTP mode
+- `source_url`: custom URL when using HTTP mode
+- `source_format`: `usgs_geojson` or `flat_json`
+- `source_table`: source table for `influxdb_table` mode (default `quake`)
+- `source_query`: optional SQL override for table mode
+- `lookback_minutes`: table query lookback window (default `15`)
+- `measurement`: destination measurement (default `earthquakes`)
+- `write_quake_schema`: write only the canonical `quake` columns (`depth`, `depthError`, `dmin`, `gap`, `horizontalError`, `id`, `latitude`, `locationSource`, `longitude`, `mag`, `magError`, `magNst`, `magSource`, `magType`, `net`, `nst`, `place`, `rms`, `status`, `time`, and `type`). Use with `measurement=quake`.
+
+- `min_magnitude`: minimum magnitude filter
+- `max_events`: max events processed per run
+- `skip_unchanged`: skip unchanged events based on cached marker
+- `use_event_timestamp`: write event timestamp vs trigger time
+
+## Install / deploy
+
+### Option A: Generic InfluxDB 3 trigger create (from a node with `influxdb3` CLI)
+
+1) Place plugin file where CLI can read it:
+
+- `earthquake_sampler.py`
+
+2) Create a scheduled trigger that fetches the USGS GeoJSON `all_hour` feed and writes it directly to `usgs.quake`:
+
+```bash
+influxdb3 create trigger \
+  --database usgs \
+  --path ./earthquake_sampler.py \
+  --upload \
+  --trigger-spec "every:2m" \
+  --trigger-arguments "source_type=http,feed=all_hour,measurement=quake,write_quake_schema=true,max_events=500,min_magnitude=0.0,skip_unchanged=true,use_event_timestamp=true" \
+  usgs_to_quake
+```
+
+### Option B: Local Kubernetes install (namespace `influxdb3`, processor pod)
+
+This matches a processor pod named `db3-influxdb3-enterprise-processor-0`.
+
+1) Copy plugin to processor pod:
+
+```bash
+kubectl -n influxdb3 cp ./earthquake_sampler.py db3-influxdb3-enterprise-processor-0:/tmp/earthquake_sampler.py
+```
+
+2) Get admin token from secret and create trigger in DB `usgs`:
+
+```bash
+TOKEN=$(kubectl -n influxdb3 get secret influxdb3-admin-token -o jsonpath='{.data.TOKEN}' | base64 -d)
+
+kubectl -n influxdb3 exec db3-influxdb3-enterprise-processor-0 -- sh -lc "
+influxdb3 create trigger \
+  --database usgs \
+  --token '$TOKEN' \
+  --host http://127.0.0.1:8181 \
+  --node-spec 'nodes:db3-influxdb3-enterprise-processor-0' \
+  --path /tmp/earthquake_sampler.py \
+  --upload \
+  --trigger-spec 'every:2m' \
+  --trigger-arguments 'source_type=http,feed=all_hour,measurement=quake,write_quake_schema=true,max_events=500,min_magnitude=0.0,skip_unchanged=true,use_event_timestamp=true' \
+  usgs_to_quake
+"
+```
+
+## Validate plugin output
+
+```bash
+# Trigger metadata
+influxdb3 query --database usgs "SELECT trigger_name, trigger_specification, disabled FROM system.processing_engine_triggers"
+
+# Plugin logs
+influxdb3 query --database usgs "SELECT time, trigger_name, log_level, log_text FROM system.processing_engine_logs WHERE trigger_name='usgs_to_quake' ORDER BY time DESC LIMIT 20"
+
+# Event data
+influxdb3 query --database usgs "SELECT id, mag, place, latitude, longitude, depth, time FROM quake ORDER BY time DESC LIMIT 20"
+```
+
+## Notes
+
+- This repo is intentionally minimal: docs + plugin code.
+- No extra Python dependencies are required in plugin code (stdlib only).
+- The plugin does not create or write an `earthquake_plugin_stats` table.
+- `write_quake_schema=true` is intended for an existing `quake` table with the documented schema; it never writes tags or normalized-only columns such as `event_id` or `magnitude`.

--- a/influxdata/earthquake_sampler/README.md
+++ b/influxdata/earthquake_sampler/README.md
@@ -33,7 +33,7 @@ On each scheduled run, the plugin:
 - `source_query`: optional SQL override for table mode
 - `lookback_minutes`: table query lookback window (default `15`)
 - `measurement`: destination measurement (default `earthquakes`)
-- `write_quake_schema`: write only the canonical `quake` columns (`depth`, `depthError`, `dmin`, `gap`, `horizontalError`, `id`, `latitude`, `locationSource`, `longitude`, `mag`, `magError`, `magNst`, `magSource`, `magType`, `net`, `nst`, `place`, `rms`, `status`, `time`, and `type`). Use with `measurement=quake`.
+- `write_quake_schema`: write only the canonical `quake` columns (`depth`, `depthError`, `dmin`, `gap`, `horizontalError`, `id`, `latitude`, `locationSource`, `longitude`, `mag`, `magError`, `magNst`, `magSource`, `magType`, `net`, `nst`, `place`, `rms`, `status`, `time`, and `type`). Use with `measurement=quake`. Note: `depthError`, `horizontalError`, `magError`, `magNst`, `locationSource`, and `magSource` exist only in USGS CSV feeds, not GeoJSON, so they are written only when a `flat_json` or `influxdb_table` source supplies them.
 
 - `min_magnitude`: optional minimum magnitude filter; when omitted, nothing is filtered (USGS feeds include negative-magnitude microseisms)
 - `max_events`: max events processed per run

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -60,7 +60,7 @@
         {
             "name": "min_magnitude",
             "example": "2.5",
-            "description": "Minimum earthquake magnitude to ingest from the selected feed. Defaults to 0.",
+            "description": "Optional minimum earthquake magnitude to ingest. When omitted, no magnitude filtering is applied (USGS feeds include negative-magnitude microseisms and events with no magnitude).",
             "required": false
         },
         {
@@ -154,7 +154,7 @@ def _parse_bool(value: Any, default: bool) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
-def _parse_float(value: Any, default: float) -> float:
+def _parse_float(value: Any, default: Optional[float]) -> Optional[float]:
     if value is None:
         return default
     try:
@@ -565,7 +565,7 @@ def process_scheduled_call(
 
     measurement = _safe_string(args.get("measurement", "earthquakes")) or "earthquakes"
     write_quake_schema = _parse_bool(args.get("write_quake_schema"), False)
-    min_magnitude = _parse_float(args.get("min_magnitude"), 0.0)
+    min_magnitude = _parse_float(args.get("min_magnitude"), None)
     max_events = max(1, _parse_int(args.get("max_events"), 250))
     use_event_timestamp = _parse_bool(args.get("use_event_timestamp"), True)
     skip_unchanged = _parse_bool(args.get("skip_unchanged"), True)
@@ -637,7 +637,7 @@ def process_scheduled_call(
         except (TypeError, ValueError):
             magnitude = None
 
-        if magnitude is None or magnitude < min_magnitude:
+        if min_magnitude is not None and (magnitude is None or magnitude < min_magnitude):
             skipped += 1
             continue
 

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -34,7 +34,7 @@
         },
         {
             "name": "source_query",
-            "example": "SELECT * FROM \"quake\" WHERE time >= now() - INTERVAL '15 minutes' ORDER BY time DESC LIMIT 500",
+            "example": "SELECT * FROM quake WHERE time >= now() - INTERVAL '15 minutes' ORDER BY time DESC LIMIT 500",
             "description": "Optional SQL query override used when `source_type=influxdb_table`.",
             "required": false
         },

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -41,7 +41,7 @@
         {
             "name": "lookback_minutes",
             "example": "15",
-            "description": "Lookback window for `source_type=influxdb_table` when `source_query` is not provided. Defaults to 15.",
+            "description": "Initial lookback window in minutes for `source_type=influxdb_table` when `source_query` is not provided. Later runs page forward from the cached fetch watermark while `skip_unchanged=true`. Defaults to 15.",
             "required": false
         },
         {
@@ -288,22 +288,39 @@ def _fetch_payload(url: str, user_agent: str) -> Dict[str, Any]:
         return json.loads(response.read().decode("utf-8"))
 
 
+def _ns_to_rfc3339(ns: int) -> str:
+    seconds, remainder = divmod(int(ns), 1_000_000_000)
+    dt = datetime.fromtimestamp(seconds, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S") + f".{remainder:09d}Z"
+
+
+def _table_watermark_key(measurement: str, source_table: str) -> str:
+    return f"earthquake_sampler:table_watermark:{measurement}:{source_table}"
+
+
 def _fetch_table_rows(
     influxdb3_local,
     source_table: str,
     max_events: int,
     lookback_minutes: int,
     source_query: str,
+    watermark_ns: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     if source_query.strip():
         query = source_query
     else:
-        safe_lookback = max(1, int(lookback_minutes))
         safe_table = source_table.replace('"', '""')
+        # Page oldest-first from the fetch watermark: DESC + LIMIT starved
+        # rows between the watermark and the newest LIMIT rows under load.
+        if watermark_ns is not None:
+            time_filter = f"time > '{_ns_to_rfc3339(watermark_ns)}'"
+        else:
+            safe_lookback = max(1, int(lookback_minutes))
+            time_filter = f"time >= now() - INTERVAL '{safe_lookback} minutes'"
         query = (
             f'SELECT * FROM "{safe_table}" '
-            f"WHERE time >= now() - INTERVAL '{safe_lookback} minutes' "
-            f"ORDER BY time DESC "
+            f"WHERE {time_filter} "
+            f"ORDER BY time ASC "
             f"LIMIT {max_events}"
         )
     rows = influxdb3_local.query(query)
@@ -619,6 +636,9 @@ def process_scheduled_call(
 
     items: List[Dict[str, Any]] = []
     if source_type == "influxdb_table":
+        watermark_key = _table_watermark_key(measurement, source_table)
+        use_watermark = skip_unchanged and not source_query.strip()
+        watermark_ns = _get_cached_int(influxdb3_local, watermark_key) if use_watermark else None
         try:
             items = _fetch_table_rows(
                 influxdb3_local=influxdb3_local,
@@ -626,11 +646,21 @@ def process_scheduled_call(
                 max_events=max_events,
                 lookback_minutes=lookback_minutes,
                 source_query=source_query,
+                watermark_ns=watermark_ns,
             )
             source_format = "flat_json"
         except Exception as e:
             influxdb3_local.error(f"[{task_id}] Query error while reading source table '{source_table}': {_exc(e)}")
             return
+        if use_watermark and items:
+            # Fetch progress, not write progress: dedup is the per-event
+            # cache's job; this only keeps paging moving forward.
+            max_time_ns = max(
+                (t for t in (_coerce_time_ns(r.get("time")) for r in items) if t is not None),
+                default=None,
+            )
+            if max_time_ns is not None:
+                influxdb3_local.cache.put(watermark_key, max_time_ns, ttl=EVENT_MARKER_TTL_SECONDS)
     else:
         url = source_url if source_url else FEED_URLS[feed]
         scheme = urlparse(url).scheme.lower()

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -257,29 +257,39 @@ def _coerce_time_ns(value: Any) -> Optional[int]:
     flat JSON feeds may use ISO strings or epoch seconds/milliseconds, so the
     unit of a bare number is inferred from its magnitude.
     """
-    if value is None:
+    if value is None or isinstance(value, bool):
         return None
     if isinstance(value, str):
         ns = _to_ns_from_iso(value)
         if ns is not None:
             return ns
         try:
-            value = float(value)
+            value = int(value)
         except (TypeError, ValueError):
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                return None
+    # Integers stay on an exact path: epoch nanoseconds exceed float64's
+    # 53-bit mantissa, and a float round-trip perturbs the low ~8 digits —
+    # which also un-aligns ms timestamps and defeats the sub-ms dedup offset.
+    if isinstance(value, float):
+        if not math.isfinite(value):
             return None
-    try:
-        numeric = float(value)
-    except (TypeError, ValueError):
+        if 0 < value <= 1e11:  # fractional epoch seconds
+            return int(value * 1_000_000_000)
+        value = int(value)
+    elif not isinstance(value, int):
         return None
-    if not math.isfinite(numeric) or numeric <= 0:
+    if value <= 0:
         return None
-    if numeric > 1e17:  # nanoseconds
-        return int(numeric)
-    if numeric > 1e14:  # microseconds
-        return int(numeric * 1_000)
-    if numeric > 1e11:  # milliseconds
-        return int(numeric * 1_000_000)
-    return int(numeric * 1_000_000_000)  # seconds
+    if value > 10**17:  # nanoseconds
+        return value
+    if value > 10**14:  # microseconds
+        return value * 1_000
+    if value > 10**11:  # milliseconds
+        return value * 1_000_000
+    return value * 1_000_000_000  # seconds
 
 
 # Outlives the longest (monthly) feed window, so an event's marker survives

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -78,7 +78,7 @@
         {
             "name": "skip_unchanged",
             "example": "true",
-            "description": "Skip events whose update marker is not newer than the last processed run. Defaults to true.",
+            "description": "Skip events whose update marker is not newer than the last written copy of the same event (per-event cache). Events without an id are always written. Defaults to true.",
             "required": false
         },
         {
@@ -245,6 +245,23 @@ def _coerce_time_ns(value: Any) -> Optional[int]:
     if numeric > 1e11:  # milliseconds
         return int(numeric * 1_000_000)
     return int(numeric * 1_000_000_000)  # seconds
+
+
+# Outlives the longest (monthly) feed window, so an event's marker survives
+# for as long as the event can still appear in fetched data.
+EVENT_MARKER_TTL_SECONDS = 45 * 24 * 3600
+
+
+def _event_marker_key(measurement: str, event_id: Any) -> str:
+    return f"earthquake_sampler:event_marker:{measurement}:{event_id}"
+
+
+def _get_cached_int(influxdb3_local, key: str) -> Optional[int]:
+    raw = influxdb3_local.cache.get(key)
+    try:
+        return int(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def _to_update_marker_ms(event: Dict[str, Any]) -> int:
@@ -599,7 +616,6 @@ def process_scheduled_call(
     user_agent = _safe_string(args.get("user_agent", "InfluxDB3-Earthquake-Plugin/1.0")) or "InfluxDB3-Earthquake-Plugin/1.0"
 
     now_ns = int(call_time.replace(tzinfo=timezone.utc).timestamp() * 1_000_000_000)
-    cache_key = f"earthquake_sampler:last_update_marker:{source_type}:{source}:{source_format}:{measurement}"
 
     items: List[Dict[str, Any]] = []
     if source_type == "influxdb_table":
@@ -647,17 +663,12 @@ def process_scheduled_call(
 
     normalized = [_normalize_event(item, source_format) for item in items]
 
-    last_seen_marker = influxdb3_local.cache.get(cache_key)
-    try:
-        last_seen_marker = int(last_seen_marker) if last_seen_marker is not None else None
-    except (TypeError, ValueError):
-        last_seen_marker = None
-
     fetched = 0
     written = 0
     skipped = 0
-    max_marker_this_run: Optional[int] = last_seen_marker
 
+    # Newest-first so the max_events cap prioritizes recent events; anything
+    # deferred by the cap stays uncached and is picked up on a later run.
     normalized.sort(key=_to_update_marker_ms, reverse=True)
 
     for event in normalized:
@@ -676,9 +687,13 @@ def process_scheduled_call(
             continue
 
         marker = _to_update_marker_ms(event)
-        if skip_unchanged and last_seen_marker is not None and marker <= last_seen_marker:
-            skipped += 1
-            continue
+        event_id = event.get("event_id")
+        marker_key = _event_marker_key(measurement, event_id) if event_id is not None else None
+        if skip_unchanged and marker_key is not None:
+            last_marker = _get_cached_int(influxdb3_local, marker_key)
+            if last_marker is not None and marker <= last_marker:
+                skipped += 1
+                continue
 
         try:
             if write_quake_schema:
@@ -699,14 +714,11 @@ def process_scheduled_call(
                 )
             if did_write:
                 written += 1
-                if max_marker_this_run is None or marker > max_marker_this_run:
-                    max_marker_this_run = marker
+                if marker_key is not None:
+                    influxdb3_local.cache.put(marker_key, marker, ttl=EVENT_MARKER_TTL_SECONDS)
         except Exception as e:
             skipped += 1
             influxdb3_local.error(f"[{task_id}] Failed to write earthquake event: {_exc(e)}")
-
-    if max_marker_this_run is not None:
-        influxdb3_local.cache.put(cache_key, max_marker_this_run, ttl=None)
 
     influxdb3_local.info(
         f"[{task_id}] Earthquake sampler complete: "

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -35,7 +35,7 @@
         {
             "name": "source_query",
             "example": "SELECT * FROM quake WHERE time >= now() - INTERVAL '15 minutes' ORDER BY time DESC LIMIT 500",
-            "description": "Optional SQL query override used when `source_type=influxdb_table`.",
+            "description": "Optional SQL query override used when `source_type=influxdb_table`. Trigger arguments are comma-separated, so a query containing commas must be supplied through `config_file_path` instead.",
             "required": false
         },
         {
@@ -92,6 +92,12 @@
             "example": "false",
             "description": "When true, full exception messages are logged. When false (default), only exception types are logged.",
             "required": false
+        },
+        {
+            "name": "config_file_path",
+            "example": "earthquake_sampler_config_scheduler.toml",
+            "description": "Path to a TOML configuration file, relative to the plugin directory. Values in the file override the inline trigger arguments.",
+            "required": false
         }
     ]
 }
@@ -106,6 +112,11 @@ from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
+
+from influxdata_plugin_utils.config import Validator, load_plugin_config
+from influxdata_plugin_utils.introspection import get_table_names
+from influxdata_plugin_utils.parsing import parse_bool, parse_int
+from influxdata_plugin_utils.write import build_line_typed, write_data
 
 
 # At server runtime LineBuilder is injected as a builtin. In test environments
@@ -147,49 +158,103 @@ def _exc(e: BaseException) -> str:
     return str(e) if _ENABLE_FULL_LOGGING else type(e).__name__
 
 
-class ConfigError(ValueError):
-    """Raised when a trigger argument has an invalid value."""
+DEFAULT_USER_AGENT = "InfluxDB3-Earthquake-Plugin/1.0"
 
 
-_TRUE_STRINGS = {"1", "true", "yes", "y", "on"}
-_FALSE_STRINGS = {"0", "false", "no", "n", "off"}
+def _optional_text(raw: Any) -> str:
+    return "" if raw is None else str(raw).strip()
 
 
-def _parse_bool_arg(name: str, value: Any, default: bool) -> bool:
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    text = str(value).strip().lower()
-    if text in _TRUE_STRINGS:
-        return True
-    if text in _FALSE_STRINGS:
-        return False
-    raise ConfigError(f"{name} must be a boolean (true/false), got '{value}'")
+def _text_or(default: str):
+    """Build a cast that falls back to `default` for empty or missing text."""
+
+    def cast(raw: Any) -> str:
+        return _optional_text(raw) or default
+
+    return cast
 
 
-def _parse_float_arg(name: str, value: Any, default: Optional[float]) -> Optional[float]:
-    if value is None:
-        return default
+def _choice_or(default: str):
+    """Cast for `is_in` arguments: normalize case, fall back to `default` when empty."""
+
+    def cast(raw: Any) -> str:
+        return _optional_text(raw).lower() or default
+
+    return cast
+
+
+def _finite_float(raw: Any) -> Optional[float]:
+    if raw is None:
+        return None
+    value = float(raw)
+    if not math.isfinite(value):
+        raise ValueError(f"must be a finite number, got {raw!r}")
+    return value
+
+
+def _positive_int(raw: Any) -> int:
+    return parse_int(raw, minimum=1)
+
+
+_VALIDATORS = [
+    Validator("feed", default="all_hour", cast=_choice_or("all_hour"), is_in=sorted(FEED_URLS)),
+    Validator("source_url", default="", cast=_optional_text),
+    Validator(
+        "source_type",
+        default="http",
+        cast=_choice_or("http"),
+        is_in=["http", "influxdb_table"],
+    ),
+    Validator(
+        "source_format",
+        default="usgs_geojson",
+        cast=_choice_or("usgs_geojson"),
+        is_in=["usgs_geojson", "flat_json"],
+    ),
+    Validator("source_table", default="quake", cast=_text_or("quake")),
+    Validator("source_query", default="", cast=_optional_text),
+    Validator("lookback_minutes", default=15, cast=_positive_int),
+    Validator("measurement", default="earthquakes", cast=_text_or("earthquakes")),
+    Validator("write_quake_schema", default=False, cast=parse_bool),
+    Validator("min_magnitude", default=None, cast=_finite_float),
+    Validator("max_events", default=250, cast=_positive_int),
+    Validator("use_event_timestamp", default=True, cast=parse_bool),
+    Validator("skip_unchanged", default=True, cast=parse_bool),
+    Validator("user_agent", default=DEFAULT_USER_AGENT, cast=_text_or(DEFAULT_USER_AGENT)),
+    Validator("enable_full_logging", default=False, cast=parse_bool),
+]
+
+
+def _load_config(influxdb3_local, args: Optional[Dict[str, Any]], task_id: str) -> Optional[Dict[str, Any]]:
+    """Load and validate the trigger configuration.
+
+    Returns:
+        Config keyed by lower-case name, or None when the inline arguments
+        themselves are invalid.
+    """
+    args = args or {}
+    config_file_path = args.get("config_file_path")
+    if config_file_path and not str(config_file_path).endswith(".toml"):
+        influxdb3_local.error(f"[{task_id}] Invalid config file format: expected a .toml file")
+        config_file_path = None
+
     try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        raise ConfigError(f"{name} must be a number, got '{value}'")
-    if not math.isfinite(parsed):
-        raise ConfigError(f"{name} must be finite, got '{value}'")
-    return parsed
+        loaded = load_plugin_config(args, validators=_VALIDATORS, source="args")
+    except Exception as e:
+        influxdb3_local.error(f"[{task_id}] Invalid configuration: {e}")
+        return None
 
+    if config_file_path:
+        try:
+            loaded = load_plugin_config(args, validators=_VALIDATORS, source="merge")
+            influxdb3_local.info(f"[{task_id}] Loaded configuration from {config_file_path}")
+        except Exception as e:
+            influxdb3_local.error(
+                f"[{task_id}] Failed to apply config file '{config_file_path}': {_exc(e)}. "
+                f"Continuing with inline arguments"
+            )
 
-def _parse_int_arg(name: str, value: Any, default: int, minimum: int) -> int:
-    if value is None:
-        return default
-    try:
-        parsed = int(str(value).strip())
-    except (TypeError, ValueError):
-        raise ConfigError(f"{name} must be an integer, got '{value}'")
-    if parsed < minimum:
-        raise ConfigError(f"{name} must be >= {minimum}, got {parsed}")
-    return parsed
+    return {key.lower(): value for key, value in loaded.as_dict().items()}
 
 
 def _redact_url(url: str) -> str:
@@ -217,19 +282,29 @@ def _safe_tag(value: Any, fallback: str = "unknown") -> str:
     return out.replace(",", " ").replace("=", " ")
 
 
-def _safe_string(value: Any) -> str:
-    if value is None:
-        return ""
-    return str(value)
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
 def _to_ns_from_ms(ms: Any) -> Optional[int]:
-    if ms is None:
+    """Convert epoch milliseconds to nanoseconds on an exact integer path."""
+    if ms is None or isinstance(ms, bool):
         return None
-    try:
-        return int(float(ms) * 1_000_000)
-    except (TypeError, ValueError):
-        return None
+    if not isinstance(ms, (int, float)):
+        text = str(ms).strip()
+        if not text:
+            return None
+        try:
+            ms = int(text)
+        except ValueError:
+            try:
+                ms = float(text)
+            except ValueError:
+                return None
+    if isinstance(ms, float):
+        if not math.isfinite(ms):
+            return None
+        return int(round(ms * 1_000)) * 1_000
+    return ms * 1_000_000
 
 
 def _to_ns_from_iso(ts: Any) -> Optional[int]:
@@ -244,9 +319,10 @@ def _to_ns_from_iso(ts: Any) -> Optional[int]:
             dt = dt.replace(tzinfo=timezone.utc)
         else:
             dt = dt.astimezone(timezone.utc)
-        return int(dt.timestamp() * 1_000_000_000)
     except Exception:
         return None
+    delta = dt - _EPOCH
+    return (delta.days * 86_400 + delta.seconds) * 1_000_000_000 + delta.microseconds * 1_000
 
 
 
@@ -310,19 +386,13 @@ def _get_cached_int(influxdb3_local, key: str) -> Optional[int]:
 
 
 def _to_update_marker_ms(event: Dict[str, Any]) -> int:
-    raw = event.get("updated_ms")
-    if raw is not None:
-        try:
-            return int(raw)
-        except (TypeError, ValueError):
-            pass
-    ts_ns = event.get("event_time_ns")
-    if ts_ns is not None:
-        try:
-            return int(int(ts_ns) / 1_000_000)
-        except (TypeError, ValueError):
-            pass
-    return 0
+    """Millisecond marker that detects a revised copy of the same event."""
+    marker_ns = _coerce_time_ns(event.get("updated_ms"))
+    if marker_ns is None:
+        marker_ns = _coerce_time_ns(event.get("event_time_ns"))
+    if marker_ns is None:
+        return 0
+    return marker_ns // 1_000_000
 
 
 def _fetch_payload(url: str, user_agent: str) -> Dict[str, Any]:
@@ -494,6 +564,68 @@ def _event_timestamp_ns(
     return timestamp_ns
 
 
+EVENT_FLOAT_FIELDS = (
+    "magnitude",
+    "depth_km",
+    "longitude",
+    "latitude",
+    "gap_degrees",
+    "distance_km",
+    "rms",
+    "mmi",
+    "depth_error",
+    "horizontal_error",
+    "mag_error",
+)
+
+EVENT_INT_FIELDS = (
+    "significance",
+    "felt_reports",
+    "tsunami",
+    "nst",
+    "mag_nst",
+    "updated_ms",
+)
+
+EVENT_STRING_FIELDS = (
+    "event_id",
+    "place",
+    "title",
+    "url",
+    "location_source",
+    "mag_source",
+)
+
+
+def _float_or_none(raw: Any) -> Optional[float]:
+    """Coerce to a finite float, or None so the field is left out of the line."""
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if math.isfinite(value) else None
+
+
+def _int_or_none(raw: Any) -> Optional[int]:
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _write_line(influxdb3_local, line) -> None:
+    """Write one line via write_sync, which raises inline so the caller can count it.
+
+    Retries stay off: a rejected line should be reported at once rather than
+    sleeping through a backoff for every event in the run.
+    """
+    write_data(influxdb3_local, [line], batch=False, retries=0, no_sync=True)
+
+
 def _write_event(
     influxdb3_local,
     measurement: str,
@@ -503,70 +635,30 @@ def _write_event(
 ) -> bool:
     timestamp_ns = _event_timestamp_ns(event, fallback_ts_ns, use_event_timestamp)
 
-    line = LineBuilder(measurement).time_ns(timestamp_ns)
-    line.tag("event_type", _safe_tag(event.get("event_type"), "earthquake"))
-    line.tag("status", _safe_tag(event.get("status"), "unknown"))
-    line.tag("alert", _safe_tag(event.get("alert"), "none"))
-    line.tag("net", _safe_tag(event.get("net"), "unknown"))
-    line.tag("mag_type", _safe_tag(event.get("mag_type"), "unknown"))
+    typed_fields: Dict[str, Any] = {
+        name: (_float_or_none(event.get(name)), "float") for name in EVENT_FLOAT_FIELDS
+    }
+    typed_fields.update(
+        {name: (_int_or_none(event.get(name)), "int") for name in EVENT_INT_FIELDS}
+    )
+    typed_fields.update(
+        {name: (event.get(name), "string") for name in EVENT_STRING_FIELDS}
+    )
 
-    for field_name in (
-        "magnitude",
-        "depth_km",
-        "longitude",
-        "latitude",
-        "gap_degrees",
-        "distance_km",
-        "rms",
-        "mmi",
-        "depth_error",
-        "horizontal_error",
-        "mag_error",
-    ):
-        raw = event.get(field_name)
-        if raw is None:
-            continue
-        try:
-            val = float(raw)
-            if math.isfinite(val):
-                line.float64_field(field_name, val)
-        except (TypeError, ValueError):
-            continue
-
-    for field_name in (
-        "significance",
-        "felt_reports",
-        "tsunami",
-        "nst",
-        "mag_nst",
-    ):
-        raw = event.get(field_name)
-        if raw is None:
-            continue
-        try:
-            line.int64_field(field_name, int(raw))
-        except (TypeError, ValueError):
-            continue
-
-    updated_ms = event.get("updated_ms")
-    if updated_ms is not None:
-        try:
-            line.int64_field("updated_ms", int(updated_ms))
-        except (TypeError, ValueError):
-            pass
-
-    line.string_field("event_id", _safe_string(event.get("event_id")))
-    line.string_field("place", _safe_string(event.get("place")))
-    line.string_field("title", _safe_string(event.get("title")))
-    line.string_field("url", _safe_string(event.get("url")))
-    for field_name in ("location_source", "mag_source"):
-        raw = event.get(field_name)
-        if raw is not None:
-            line.string_field(field_name, _safe_string(raw))
-
-    # Buffered write() only flushes after the trigger returns, so a failed
-    # write could never be caught or counted here; write_sync raises inline.
-    influxdb3_local.write_sync(line, no_sync=True)
+    line = build_line_typed(
+        LineBuilder,
+        measurement,
+        tags={
+            "event_type": _safe_tag(event.get("event_type"), "earthquake"),
+            "status": _safe_tag(event.get("status"), "unknown"),
+            "alert": _safe_tag(event.get("alert"), "none"),
+            "net": _safe_tag(event.get("net"), "unknown"),
+            "mag_type": _safe_tag(event.get("mag_type"), "unknown"),
+        },
+        typed_fields=typed_fields,
+        time_ns=timestamp_ns,
+    )
+    _write_line(influxdb3_local, line)
     return True
 
 
@@ -607,24 +699,24 @@ def _write_quake_event(
     """Write a normalized USGS event to a table using only the canonical quake schema."""
     timestamp_ns = _event_timestamp_ns(event, fallback_ts_ns, use_event_timestamp)
 
-    line = LineBuilder(measurement).time_ns(timestamp_ns)
-    for column, event_key in QUAKE_FLOAT_COLUMN_MAP.items():
-        value = event.get(event_key)
-        if value is None:
-            continue
-        try:
-            numeric = float(value)
-        except (TypeError, ValueError):
-            continue
-        if math.isfinite(numeric):
-            line.float64_field(column, numeric)
+    typed_fields: Dict[str, Any] = {
+        column: (_float_or_none(event.get(event_key)), "float")
+        for column, event_key in QUAKE_FLOAT_COLUMN_MAP.items()
+    }
+    typed_fields.update(
+        {
+            column: (event.get(event_key), "string")
+            for column, event_key in QUAKE_STRING_COLUMN_MAP.items()
+        }
+    )
 
-    for column, event_key in QUAKE_STRING_COLUMN_MAP.items():
-        value = event.get(event_key)
-        if value is not None:
-            line.string_field(column, _safe_string(value))
-
-    influxdb3_local.write_sync(line, no_sync=True)
+    line = build_line_typed(
+        LineBuilder,
+        measurement,
+        typed_fields=typed_fields,
+        time_ns=timestamp_ns,
+    )
+    _write_line(influxdb3_local, line)
     return True
 
 
@@ -635,40 +727,33 @@ def process_scheduled_call(
     args: Optional[Dict[str, Any]] = None,
 ) -> None:
     task_id = str(uuid.uuid4())
-    args = args or {}
 
     global _ENABLE_FULL_LOGGING
     try:
-        _ENABLE_FULL_LOGGING = _parse_bool_arg(
-            "enable_full_logging", args.get("enable_full_logging"), False
-        )
+        _ENABLE_FULL_LOGGING = parse_bool((args or {}).get("enable_full_logging", False))
+    except ValueError:
+        _ENABLE_FULL_LOGGING = False
 
-        source_type = _safe_string(args.get("source_type", "http")).lower() or "http"
-        if source_type not in {"http", "influxdb_table"}:
-            raise ConfigError(f"source_type must be 'http' or 'influxdb_table', got '{source_type}'")
-
-        source_url = _safe_string(args.get("source_url"))
-        source_format = _safe_string(args.get("source_format", "usgs_geojson")).lower() or "usgs_geojson"
-        if source_format not in {"usgs_geojson", "flat_json"}:
-            raise ConfigError(f"source_format must be 'usgs_geojson' or 'flat_json', got '{source_format}'")
-
-        feed = _safe_string(args.get("feed", "all_hour"))
-        if feed not in FEED_URLS:
-            raise ConfigError(f"unknown feed '{feed}'; valid keys: {', '.join(sorted(FEED_URLS))}")
-
-        source_table = _safe_string(args.get("source_table", "quake")) or "quake"
-        source_query = _safe_string(args.get("source_query"))
-        lookback_minutes = _parse_int_arg("lookback_minutes", args.get("lookback_minutes"), 15, minimum=1)
-
-        measurement = _safe_string(args.get("measurement", "earthquakes")) or "earthquakes"
-        write_quake_schema = _parse_bool_arg("write_quake_schema", args.get("write_quake_schema"), False)
-        min_magnitude = _parse_float_arg("min_magnitude", args.get("min_magnitude"), None)
-        max_events = _parse_int_arg("max_events", args.get("max_events"), 250, minimum=1)
-        use_event_timestamp = _parse_bool_arg("use_event_timestamp", args.get("use_event_timestamp"), True)
-        skip_unchanged = _parse_bool_arg("skip_unchanged", args.get("skip_unchanged"), True)
-    except ConfigError as e:
-        influxdb3_local.error(f"[{task_id}] Invalid configuration: {e}")
+    config = _load_config(influxdb3_local, args, task_id)
+    if config is None:
         return
+
+    _ENABLE_FULL_LOGGING = config["enable_full_logging"]
+
+    source_type: str = config["source_type"]
+    source_url: str = config["source_url"]
+    source_format: str = config["source_format"]
+    feed: str = config["feed"]
+    source_table: str = config["source_table"]
+    source_query: str = config["source_query"]
+    lookback_minutes: int = config["lookback_minutes"]
+    measurement: str = config["measurement"]
+    write_quake_schema: bool = config["write_quake_schema"]
+    min_magnitude: Optional[float] = config["min_magnitude"]
+    max_events: int = config["max_events"]
+    use_event_timestamp: bool = config["use_event_timestamp"]
+    skip_unchanged: bool = config["skip_unchanged"]
+    user_agent: str = config["user_agent"]
 
     if write_quake_schema and not use_event_timestamp:
         # Quake-schema rows have no tags, so a shared trigger timestamp would
@@ -678,7 +763,6 @@ def process_scheduled_call(
             f"using event timestamps to keep events distinct"
         )
         use_event_timestamp = True
-    user_agent = _safe_string(args.get("user_agent", "InfluxDB3-Earthquake-Plugin/1.0")) or "InfluxDB3-Earthquake-Plugin/1.0"
 
     # Display name for logs: URLs are stripped of userinfo/query string and
     # custom SQL is truncated so credentials or literals stay out of the logs.
@@ -691,6 +775,19 @@ def process_scheduled_call(
 
     items: List[Dict[str, Any]] = []
     if source_type == "influxdb_table":
+        if not source_query:
+            # Uncached: a cached list would keep rejecting a table created later.
+            try:
+                table_names = get_table_names(influxdb3_local, use_cache=False)
+            except Exception as e:
+                influxdb3_local.error(f"[{task_id}] Failed to list tables: {_exc(e)}")
+                return
+            if source_table not in table_names:
+                influxdb3_local.error(
+                    f"[{task_id}] Source table '{source_table}' not found in the trigger database"
+                )
+                return
+
         watermark_key = _table_watermark_key(measurement, source_table)
         use_watermark = skip_unchanged and not source_query.strip()
         watermark_ns = _get_cached_int(influxdb3_local, watermark_key) if use_watermark else None
@@ -803,7 +900,10 @@ def process_scheduled_call(
                     influxdb3_local.cache.put(marker_key, marker, ttl=EVENT_MARKER_TTL_SECONDS)
         except Exception as e:
             skipped += 1
-            influxdb3_local.error(f"[{task_id}] Failed to write earthquake event: {_exc(e)}")
+            influxdb3_local.error(
+                f"[{task_id}] Failed to write earthquake event "
+                f"'{event.get('event_id')}': {_exc(e)}"
+            )
 
     influxdb3_local.info(
         f"[{task_id}] Earthquake sampler complete: "

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -214,6 +214,38 @@ def _to_ns_from_iso(ts: Any) -> Optional[int]:
 
 
 
+def _coerce_time_ns(value: Any) -> Optional[int]:
+    """Coerce a timestamp of unknown shape to epoch nanoseconds.
+
+    InfluxDB queries return the time column as an integer (nanoseconds), while
+    flat JSON feeds may use ISO strings or epoch seconds/milliseconds, so the
+    unit of a bare number is inferred from its magnitude.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        ns = _to_ns_from_iso(value)
+        if ns is not None:
+            return ns
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric) or numeric <= 0:
+        return None
+    if numeric > 1e17:  # nanoseconds
+        return int(numeric)
+    if numeric > 1e14:  # microseconds
+        return int(numeric * 1_000)
+    if numeric > 1e11:  # milliseconds
+        return int(numeric * 1_000_000)
+    return int(numeric * 1_000_000_000)  # seconds
+
+
 def _to_update_marker_ms(event: Dict[str, Any]) -> int:
     raw = event.get("updated_ms")
     if raw is not None:
@@ -320,7 +352,7 @@ def _normalize_flat_event(item: Dict[str, Any]) -> Dict[str, Any]:
         "distance_km": item.get("dmin"),
         "rms": item.get("rms"),
         "updated_ms": item.get("updated") or item.get("updatedMs"),
-        "event_time_ns": _to_ns_from_iso(item.get("time")) or _to_ns_from_ms(item.get("timeMs")),
+        "event_time_ns": _coerce_time_ns(item.get("time")) or _to_ns_from_ms(item.get("timeMs")),
         "place": item.get("place"),
         "title": item.get("title") or item.get("place"),
         "url": item.get("url"),

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -418,6 +418,7 @@ def _write_event(
         "gap_degrees",
         "distance_km",
         "rms",
+        "mmi",
         "depth_error",
         "horizontal_error",
         "mag_error",
@@ -436,7 +437,6 @@ def _write_event(
         "significance",
         "felt_reports",
         "tsunami",
-        "mmi",
         "nst",
         "mag_nst",
     ):

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -627,7 +627,7 @@ def process_scheduled_call(
     normalized.sort(key=_to_update_marker_ms, reverse=True)
 
     for event in normalized:
-        if fetched >= max_events:
+        if written >= max_events:
             break
         fetched += 1
 

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -72,7 +72,7 @@
         {
             "name": "use_event_timestamp",
             "example": "true",
-            "description": "Use event time for point timestamp. If false, use trigger execution time. Defaults to true.",
+            "description": "Use event time for point timestamp. If false, use trigger execution time. Defaults to true. Ignored (forced true) when write_quake_schema=true.",
             "required": false
         },
         {
@@ -100,6 +100,7 @@
 import json
 import math
 import uuid
+import zlib
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError, URLError
@@ -383,13 +384,17 @@ def _normalize_event(item: Dict[str, Any], source_format: str) -> Dict[str, Any]
     return _normalize_usgs_feature(item)
 
 
-def _write_event(
-    influxdb3_local,
-    measurement: str,
+def _dedup_ns_offset(event_id: Any) -> int:
+    if event_id is None:
+        return 0
+    return zlib.crc32(str(event_id).encode("utf-8")) % 1_000_000
+
+
+def _event_timestamp_ns(
     event: Dict[str, Any],
     fallback_ts_ns: int,
     use_event_timestamp: bool,
-) -> bool:
+) -> int:
     timestamp_ns = fallback_ts_ns
     event_time_ns = event.get("event_time_ns")
     if use_event_timestamp and event_time_ns is not None:
@@ -397,6 +402,26 @@ def _write_event(
             timestamp_ns = int(event_time_ns)
         except (TypeError, ValueError):
             pass
+
+    # USGS event times are millisecond-precision, and the sparse series keys
+    # (empty in quake-schema mode) make timestamp collisions between distinct
+    # events overwrite each other. Fill the zero sub-ms bits of ms-aligned
+    # timestamps with a stable per-event offset; ms-level time is unchanged,
+    # and true nanosecond timestamps (e.g. from influxdb_table sources) are
+    # left alone.
+    if timestamp_ns % 1_000_000 == 0:
+        timestamp_ns += _dedup_ns_offset(event.get("event_id"))
+    return timestamp_ns
+
+
+def _write_event(
+    influxdb3_local,
+    measurement: str,
+    event: Dict[str, Any],
+    fallback_ts_ns: int,
+    use_event_timestamp: bool,
+) -> bool:
+    timestamp_ns = _event_timestamp_ns(event, fallback_ts_ns, use_event_timestamp)
 
     line = _line_builder(measurement).time_ns(timestamp_ns)
     line.tag("event_type", _safe_tag(event.get("event_type"), "earthquake"))
@@ -500,12 +525,7 @@ def _write_quake_event(
     use_event_timestamp: bool,
 ) -> bool:
     """Write a normalized USGS event to a table using only the canonical quake schema."""
-    timestamp_ns = fallback_ts_ns
-    if use_event_timestamp and event.get("event_time_ns") is not None:
-        try:
-            timestamp_ns = int(event["event_time_ns"])
-        except (TypeError, ValueError):
-            pass
+    timestamp_ns = _event_timestamp_ns(event, fallback_ts_ns, use_event_timestamp)
 
     line = _line_builder(measurement).time_ns(timestamp_ns)
     for column, event_key in QUAKE_FLOAT_COLUMN_MAP.items():
@@ -566,6 +586,14 @@ def process_scheduled_call(
     min_magnitude = _parse_float(args.get("min_magnitude"), None)
     max_events = max(1, _parse_int(args.get("max_events"), 250))
     use_event_timestamp = _parse_bool(args.get("use_event_timestamp"), True)
+    if write_quake_schema and not use_event_timestamp:
+        # Quake-schema rows have no tags, so a shared trigger timestamp would
+        # collapse every event in a run into a single surviving row.
+        influxdb3_local.warn(
+            f"[{task_id}] use_event_timestamp=false is ignored when write_quake_schema=true; "
+            f"using event timestamps to keep events distinct"
+        )
+        use_event_timestamp = True
     skip_unchanged = _parse_bool(args.get("skip_unchanged"), True)
     user_agent = _safe_string(args.get("user_agent", "InfluxDB3-Earthquake-Plugin/1.0")) or "InfluxDB3-Earthquake-Plugin/1.0"
 

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -53,7 +53,7 @@
         {
             "name": "write_quake_schema",
             "example": "true",
-            "description": "Write USGS events using the existing quake table's column names and types. Use with measurement=quake; no tags or extra columns are written.",
+            "description": "Write USGS events using the existing quake table's column names. All numeric columns are written as float64 (matching CSV-imported quake tables); no tags or extra columns are written. Use with measurement=quake.",
             "required": false
         },
 

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -11,7 +11,7 @@
         {
             "name": "source_url",
             "example": "https://example.com/earthquakes.json",
-            "description": "Optional custom source URL. When provided, it overrides `feed` and uses `source_format` parsing.",
+            "description": "Optional custom source URL (http or https only). When provided, it overrides `feed` and uses `source_format` parsing.",
             "required": false
         },
         {
@@ -104,6 +104,7 @@ import zlib
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 
@@ -616,6 +617,13 @@ def process_scheduled_call(
             return
     else:
         url = source_url if source_url else FEED_URLS[feed]
+        scheme = urlparse(url).scheme.lower()
+        if scheme not in ("http", "https"):
+            # urlopen would happily fetch file:// or ftp:// URLs.
+            influxdb3_local.error(
+                f"[{task_id}] Unsupported source_url scheme '{scheme or 'none'}': only http and https are allowed"
+            )
+            return
         try:
             payload = _fetch_payload(url, user_agent)
         except HTTPError as e:

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -147,30 +147,65 @@ def _exc(e: BaseException) -> str:
     return str(e) if _ENABLE_FULL_LOGGING else type(e).__name__
 
 
-def _parse_bool(value: Any, default: bool) -> bool:
+class ConfigError(ValueError):
+    """Raised when a trigger argument has an invalid value."""
+
+
+_TRUE_STRINGS = {"1", "true", "yes", "y", "on"}
+_FALSE_STRINGS = {"0", "false", "no", "n", "off"}
+
+
+def _parse_bool_arg(name: str, value: Any, default: bool) -> bool:
     if value is None:
         return default
     if isinstance(value, bool):
         return value
-    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+    text = str(value).strip().lower()
+    if text in _TRUE_STRINGS:
+        return True
+    if text in _FALSE_STRINGS:
+        return False
+    raise ConfigError(f"{name} must be a boolean (true/false), got '{value}'")
 
 
-def _parse_float(value: Any, default: Optional[float]) -> Optional[float]:
+def _parse_float_arg(name: str, value: Any, default: Optional[float]) -> Optional[float]:
     if value is None:
         return default
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
-        return default
+        raise ConfigError(f"{name} must be a number, got '{value}'")
+    if not math.isfinite(parsed):
+        raise ConfigError(f"{name} must be finite, got '{value}'")
+    return parsed
 
 
-def _parse_int(value: Any, default: int) -> int:
+def _parse_int_arg(name: str, value: Any, default: int, minimum: int) -> int:
     if value is None:
         return default
     try:
-        return int(value)
+        parsed = int(str(value).strip())
     except (TypeError, ValueError):
-        return default
+        raise ConfigError(f"{name} must be an integer, got '{value}'")
+    if parsed < minimum:
+        raise ConfigError(f"{name} must be >= {minimum}, got {parsed}")
+    return parsed
+
+
+def _redact_url(url: str) -> str:
+    """Drop userinfo and query string, which may carry credentials or tokens."""
+    parts = urlparse(url)
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return f"{parts.scheme}://{host}{parts.path}"
+
+
+def _truncate(text: str, limit: int = 80) -> str:
+    text = " ".join(str(text).split())
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."
 
 
 def _safe_tag(value: Any, fallback: str = "unknown") -> str:
@@ -590,37 +625,41 @@ def process_scheduled_call(
     args: Optional[Dict[str, Any]] = None,
 ) -> None:
     task_id = str(uuid.uuid4())
+    args = args or {}
 
     global _ENABLE_FULL_LOGGING
-    _ENABLE_FULL_LOGGING = _parse_bool((args or {}).get("enable_full_logging"), False)
+    try:
+        _ENABLE_FULL_LOGGING = _parse_bool_arg(
+            "enable_full_logging", args.get("enable_full_logging"), False
+        )
 
-    args = args or {}
-    source_type = _safe_string(args.get("source_type", "http")).lower() or "http"
-    if source_type not in {"http", "influxdb_table"}:
-        source_type = "http"
+        source_type = _safe_string(args.get("source_type", "http")).lower() or "http"
+        if source_type not in {"http", "influxdb_table"}:
+            raise ConfigError(f"source_type must be 'http' or 'influxdb_table', got '{source_type}'")
 
-    source_url = _safe_string(args.get("source_url"))
-    source_format = _safe_string(args.get("source_format", "usgs_geojson")).lower() or "usgs_geojson"
-    if source_format not in {"usgs_geojson", "flat_json"}:
-        source_format = "usgs_geojson"
+        source_url = _safe_string(args.get("source_url"))
+        source_format = _safe_string(args.get("source_format", "usgs_geojson")).lower() or "usgs_geojson"
+        if source_format not in {"usgs_geojson", "flat_json"}:
+            raise ConfigError(f"source_format must be 'usgs_geojson' or 'flat_json', got '{source_format}'")
 
-    feed = _safe_string(args.get("feed", "all_hour"))
-    if feed not in FEED_URLS:
-        feed = "all_hour"
+        feed = _safe_string(args.get("feed", "all_hour"))
+        if feed not in FEED_URLS:
+            raise ConfigError(f"unknown feed '{feed}'; valid keys: {', '.join(sorted(FEED_URLS))}")
 
-    source_table = _safe_string(args.get("source_table", "quake")) or "quake"
-    source_query = _safe_string(args.get("source_query"))
-    lookback_minutes = max(1, _parse_int(args.get("lookback_minutes"), 15))
+        source_table = _safe_string(args.get("source_table", "quake")) or "quake"
+        source_query = _safe_string(args.get("source_query"))
+        lookback_minutes = _parse_int_arg("lookback_minutes", args.get("lookback_minutes"), 15, minimum=1)
 
-    source = source_url if source_url else feed
-    if source_type == "influxdb_table":
-        source = source_query if source_query else source_table
+        measurement = _safe_string(args.get("measurement", "earthquakes")) or "earthquakes"
+        write_quake_schema = _parse_bool_arg("write_quake_schema", args.get("write_quake_schema"), False)
+        min_magnitude = _parse_float_arg("min_magnitude", args.get("min_magnitude"), None)
+        max_events = _parse_int_arg("max_events", args.get("max_events"), 250, minimum=1)
+        use_event_timestamp = _parse_bool_arg("use_event_timestamp", args.get("use_event_timestamp"), True)
+        skip_unchanged = _parse_bool_arg("skip_unchanged", args.get("skip_unchanged"), True)
+    except ConfigError as e:
+        influxdb3_local.error(f"[{task_id}] Invalid configuration: {e}")
+        return
 
-    measurement = _safe_string(args.get("measurement", "earthquakes")) or "earthquakes"
-    write_quake_schema = _parse_bool(args.get("write_quake_schema"), False)
-    min_magnitude = _parse_float(args.get("min_magnitude"), None)
-    max_events = max(1, _parse_int(args.get("max_events"), 250))
-    use_event_timestamp = _parse_bool(args.get("use_event_timestamp"), True)
     if write_quake_schema and not use_event_timestamp:
         # Quake-schema rows have no tags, so a shared trigger timestamp would
         # collapse every event in a run into a single surviving row.
@@ -629,8 +668,14 @@ def process_scheduled_call(
             f"using event timestamps to keep events distinct"
         )
         use_event_timestamp = True
-    skip_unchanged = _parse_bool(args.get("skip_unchanged"), True)
     user_agent = _safe_string(args.get("user_agent", "InfluxDB3-Earthquake-Plugin/1.0")) or "InfluxDB3-Earthquake-Plugin/1.0"
+
+    # Display name for logs: URLs are stripped of userinfo/query string and
+    # custom SQL is truncated so credentials or literals stay out of the logs.
+    if source_type == "influxdb_table":
+        source = f"query:{_truncate(source_query)}" if source_query else source_table
+    else:
+        source = _redact_url(source_url) if source_url else feed
 
     now_ns = int(call_time.replace(tzinfo=timezone.utc).timestamp() * 1_000_000_000)
 

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -1,0 +1,648 @@
+"""
+{
+    "plugin_type": ["scheduled"],
+    "scheduled_args_config": [
+        {
+            "name": "feed",
+            "example": "all_hour",
+            "description": "USGS GeoJSON feed key. One of: all_hour, all_day, all_week, all_month, significant_hour, significant_day, significant_week, significant_month, 4.5_hour, 4.5_day, 4.5_week, 4.5_month, 2.5_hour, 2.5_day, 2.5_week, 2.5_month, 1.0_hour, 1.0_day, 1.0_week, 1.0_month.",
+            "required": false
+        },
+        {
+            "name": "source_url",
+            "example": "https://example.com/earthquakes.json",
+            "description": "Optional custom source URL. When provided, it overrides `feed` and uses `source_format` parsing.",
+            "required": false
+        },
+        {
+            "name": "source_type",
+            "example": "influxdb_table",
+            "description": "Data source type: `http` (default) fetches JSON from `source_url` or `feed`; `influxdb_table` queries an existing table in the trigger database.",
+            "required": false
+        },
+        {
+            "name": "source_format",
+            "example": "flat_json",
+            "description": "Source parser: `usgs_geojson` (default) or `flat_json`. Used with `source_type=http`. Use `flat_json` for records like {id, latitude, longitude, mag, time, ...}.",
+            "required": false
+        },
+        {
+            "name": "source_table",
+            "example": "quake",
+            "description": "Source table name when `source_type=influxdb_table`. Defaults to quake.",
+            "required": false
+        },
+        {
+            "name": "source_query",
+            "example": "SELECT * FROM \"quake\" WHERE time >= now() - INTERVAL '15 minutes' ORDER BY time DESC LIMIT 500",
+            "description": "Optional SQL query override used when `source_type=influxdb_table`.",
+            "required": false
+        },
+        {
+            "name": "lookback_minutes",
+            "example": "15",
+            "description": "Lookback window for `source_type=influxdb_table` when `source_query` is not provided. Defaults to 15.",
+            "required": false
+        },
+        {
+            "name": "measurement",
+            "example": "earthquakes",
+            "description": "Destination measurement name for earthquake events. Defaults to earthquakes.",
+            "required": false
+        },
+        {
+            "name": "write_quake_schema",
+            "example": "true",
+            "description": "Write USGS events using the existing quake table's column names and types. Use with measurement=quake; no tags or extra columns are written.",
+            "required": false
+        },
+
+        {
+            "name": "min_magnitude",
+            "example": "2.5",
+            "description": "Minimum earthquake magnitude to ingest from the selected feed. Defaults to 0.",
+            "required": false
+        },
+        {
+            "name": "max_events",
+            "example": "200",
+            "description": "Maximum number of events to process per run after filtering and sorting. Defaults to 250.",
+            "required": false
+        },
+        {
+            "name": "use_event_timestamp",
+            "example": "true",
+            "description": "Use event time for point timestamp. If false, use trigger execution time. Defaults to true.",
+            "required": false
+        },
+        {
+            "name": "skip_unchanged",
+            "example": "true",
+            "description": "Skip events whose update marker is not newer than the last processed run. Defaults to true.",
+            "required": false
+        },
+        {
+            "name": "user_agent",
+            "example": "InfluxDB3-Earthquake-Plugin/1.0",
+            "description": "Custom User-Agent header for API requests.",
+            "required": false
+        },
+        {
+            "name": "enable_full_logging",
+            "example": "false",
+            "description": "When true, full exception messages are logged. When false (default), only exception types are logged.",
+            "required": false
+        }
+    ]
+}
+"""
+
+import json
+import math
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def _line_builder(measurement: str):
+    import builtins
+
+    builder_cls = getattr(builtins, "LineBuilder", None)
+    if builder_cls is None:
+        raise RuntimeError("LineBuilder is not available in plugin runtime")
+    return builder_cls(measurement)
+
+
+_ENABLE_FULL_LOGGING: bool = True
+
+
+FEED_URLS = {
+    "all_hour": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson",
+    "all_day": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson",
+    "all_week": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson",
+    "all_month": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_month.geojson",
+    "significant_hour": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/significant_hour.geojson",
+    "significant_day": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/significant_day.geojson",
+    "significant_week": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/significant_week.geojson",
+    "significant_month": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/significant_month.geojson",
+    "4.5_hour": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_hour.geojson",
+    "4.5_day": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson",
+    "4.5_week": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_week.geojson",
+    "4.5_month": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_month.geojson",
+    "2.5_hour": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_hour.geojson",
+    "2.5_day": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson",
+    "2.5_week": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_week.geojson",
+    "2.5_month": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_month.geojson",
+    "1.0_hour": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/1.0_hour.geojson",
+    "1.0_day": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/1.0_day.geojson",
+    "1.0_week": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/1.0_week.geojson",
+    "1.0_month": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/1.0_month.geojson",
+}
+
+
+def _exc(e: BaseException) -> str:
+    return str(e) if _ENABLE_FULL_LOGGING else type(e).__name__
+
+
+def _parse_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _parse_float(value: Any, default: float) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_tag(value: Any, fallback: str = "unknown") -> str:
+    if value is None:
+        return fallback
+    out = str(value).strip()
+    if not out:
+        return fallback
+    return out.replace(",", " ").replace("=", " ")
+
+
+def _safe_string(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _to_ns_from_ms(ms: Any) -> Optional[int]:
+    if ms is None:
+        return None
+    try:
+        return int(float(ms) * 1_000_000)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_ns_from_iso(ts: Any) -> Optional[int]:
+    if ts is None:
+        return None
+    s = str(ts).strip()
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return int(dt.timestamp() * 1_000_000_000)
+    except Exception:
+        return None
+
+
+
+def _to_update_marker_ms(event: Dict[str, Any]) -> int:
+    raw = event.get("updated_ms")
+    if raw is not None:
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            pass
+    ts_ns = event.get("event_time_ns")
+    if ts_ns is not None:
+        try:
+            return int(int(ts_ns) / 1_000_000)
+        except (TypeError, ValueError):
+            pass
+    return 0
+
+
+def _fetch_payload(url: str, user_agent: str) -> Dict[str, Any]:
+    req = Request(url)
+    req.add_header("User-Agent", user_agent)
+    req.add_header("Accept", "application/geo+json, application/json")
+    with urlopen(req, timeout=20) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _fetch_table_rows(
+    influxdb3_local,
+    source_table: str,
+    max_events: int,
+    lookback_minutes: int,
+    source_query: str,
+) -> List[Dict[str, Any]]:
+    if source_query.strip():
+        query = source_query
+    else:
+        safe_lookback = max(1, int(lookback_minutes))
+        query = (
+            f'SELECT * FROM "{source_table}" '
+            f"WHERE time >= now() - INTERVAL '{safe_lookback} minutes' "
+            f"ORDER BY time DESC "
+            f"LIMIT {max_events}"
+        )
+    rows = influxdb3_local.query(query)
+    if not isinstance(rows, list):
+        return []
+    return [r for r in rows if isinstance(r, dict)]
+
+
+def _normalize_usgs_feature(feature: Dict[str, Any]) -> Dict[str, Any]:
+    properties = feature.get("properties", {}) if isinstance(feature, dict) else {}
+    geometry = feature.get("geometry", {}) if isinstance(feature, dict) else {}
+    coordinates = geometry.get("coordinates", []) if isinstance(geometry, dict) else []
+
+    return {
+        "event_id": feature.get("id"),
+        "event_type": properties.get("type"),
+        "status": properties.get("status"),
+        "alert": properties.get("alert"),
+        "net": properties.get("net"),
+        "mag_type": properties.get("magType"),
+        "magnitude": properties.get("mag"),
+        "significance": properties.get("sig"),
+        "felt_reports": properties.get("felt"),
+        "tsunami": properties.get("tsunami"),
+        "mmi": properties.get("mmi"),
+        "nst": properties.get("nst"),
+        "depth_km": coordinates[2] if len(coordinates) > 2 else None,
+        "longitude": coordinates[0] if len(coordinates) > 0 else None,
+        "latitude": coordinates[1] if len(coordinates) > 1 else None,
+        "gap_degrees": properties.get("gap"),
+        "distance_km": properties.get("dmin"),
+        "rms": properties.get("rms"),
+        "updated_ms": properties.get("updated"),
+        "event_time_ns": _to_ns_from_ms(properties.get("time")),
+        "place": properties.get("place"),
+        "title": properties.get("title"),
+        "url": properties.get("url"),
+        "depth_error": properties.get("depthError"),
+        "horizontal_error": properties.get("horizontalError"),
+        "mag_error": properties.get("magError"),
+        "mag_nst": properties.get("magNst"),
+        "location_source": properties.get("locationSource"),
+        "mag_source": properties.get("magSource"),
+    }
+
+
+def _normalize_flat_event(item: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "event_id": item.get("id"),
+        "event_type": item.get("type"),
+        "status": item.get("status"),
+        "alert": item.get("alert"),
+        "net": item.get("net"),
+        "mag_type": item.get("magType"),
+        "magnitude": item.get("mag"),
+        "significance": item.get("sig"),
+        "felt_reports": item.get("felt"),
+        "tsunami": item.get("tsunami"),
+        "mmi": item.get("mmi"),
+        "nst": item.get("nst"),
+        "depth_km": item.get("depth"),
+        "longitude": item.get("longitude"),
+        "latitude": item.get("latitude"),
+        "gap_degrees": item.get("gap"),
+        "distance_km": item.get("dmin"),
+        "rms": item.get("rms"),
+        "updated_ms": item.get("updated") or item.get("updatedMs"),
+        "event_time_ns": _to_ns_from_iso(item.get("time")) or _to_ns_from_ms(item.get("timeMs")),
+        "place": item.get("place"),
+        "title": item.get("title") or item.get("place"),
+        "url": item.get("url"),
+        "depth_error": item.get("depthError"),
+        "horizontal_error": item.get("horizontalError"),
+        "mag_error": item.get("magError"),
+        "mag_nst": item.get("magNst"),
+        "location_source": item.get("locationSource"),
+        "mag_source": item.get("magSource"),
+    }
+
+
+def _extract_events(payload: Dict[str, Any], source_format: str) -> List[Dict[str, Any]]:
+    if source_format == "flat_json":
+        if isinstance(payload, list):
+            return [e for e in payload if isinstance(e, dict)]
+        if isinstance(payload, dict):
+            if isinstance(payload.get("events"), list):
+                return [e for e in payload.get("events", []) if isinstance(e, dict)]
+            return [payload]
+        return []
+
+    # usgs_geojson default
+    if isinstance(payload, dict) and isinstance(payload.get("features"), list):
+        return [e for e in payload.get("features", []) if isinstance(e, dict)]
+    return []
+
+
+def _normalize_event(item: Dict[str, Any], source_format: str) -> Dict[str, Any]:
+    if source_format == "flat_json":
+        return _normalize_flat_event(item)
+    return _normalize_usgs_feature(item)
+
+
+def _write_event(
+    influxdb3_local,
+    measurement: str,
+    event: Dict[str, Any],
+    fallback_ts_ns: int,
+    use_event_timestamp: bool,
+) -> bool:
+    timestamp_ns = fallback_ts_ns
+    event_time_ns = event.get("event_time_ns")
+    if use_event_timestamp and event_time_ns is not None:
+        try:
+            timestamp_ns = int(event_time_ns)
+        except (TypeError, ValueError):
+            pass
+
+    line = _line_builder(measurement).time_ns(timestamp_ns)
+    line.tag("event_id", _safe_tag(event.get("event_id"), "unknown"))
+    line.tag("event_type", _safe_tag(event.get("event_type"), "earthquake"))
+    line.tag("status", _safe_tag(event.get("status"), "unknown"))
+    line.tag("alert", _safe_tag(event.get("alert"), "none"))
+    line.tag("net", _safe_tag(event.get("net"), "unknown"))
+    line.tag("mag_type", _safe_tag(event.get("mag_type"), "unknown"))
+
+    for field_name in (
+        "magnitude",
+        "depth_km",
+        "longitude",
+        "latitude",
+        "gap_degrees",
+        "distance_km",
+        "rms",
+        "depth_error",
+        "horizontal_error",
+        "mag_error",
+    ):
+        raw = event.get(field_name)
+        if raw is None:
+            continue
+        try:
+            val = float(raw)
+            if math.isfinite(val):
+                line.float64_field(field_name, val)
+        except (TypeError, ValueError):
+            continue
+
+    for field_name in (
+        "significance",
+        "felt_reports",
+        "tsunami",
+        "mmi",
+        "nst",
+        "mag_nst",
+    ):
+        raw = event.get(field_name)
+        if raw is None:
+            continue
+        try:
+            line.int64_field(field_name, int(raw))
+        except (TypeError, ValueError):
+            continue
+
+    updated_ms = event.get("updated_ms")
+    if updated_ms is not None:
+        try:
+            line.int64_field("updated_ms", int(updated_ms))
+        except (TypeError, ValueError):
+            pass
+
+    line.string_field("place", _safe_string(event.get("place")))
+    line.string_field("title", _safe_string(event.get("title")))
+    line.string_field("url", _safe_string(event.get("url")))
+    line.string_field("location_source", _safe_string(event.get("location_source")))
+    line.string_field("mag_source", _safe_string(event.get("mag_source")))
+
+    influxdb3_local.write(line)
+    return True
+
+
+QUAKE_FLOAT_COLUMN_MAP = {
+    "depth": "depth_km",
+    "depthError": "depth_error",
+    "dmin": "distance_km",
+    "gap": "gap_degrees",
+    "horizontalError": "horizontal_error",
+    "latitude": "latitude",
+    "longitude": "longitude",
+    "mag": "magnitude",
+    "magError": "mag_error",
+    "magNst": "mag_nst",
+    "nst": "nst",
+    "rms": "rms",
+}
+
+QUAKE_STRING_COLUMN_MAP = {
+    "id": "event_id",
+    "locationSource": "location_source",
+    "magSource": "mag_source",
+    "magType": "mag_type",
+    "net": "net",
+    "place": "place",
+    "status": "status",
+    "type": "event_type",
+}
+
+
+def _write_quake_event(
+    influxdb3_local,
+    measurement: str,
+    event: Dict[str, Any],
+    fallback_ts_ns: int,
+    use_event_timestamp: bool,
+) -> bool:
+    """Write a normalized USGS event to a table using only the canonical quake schema."""
+    timestamp_ns = fallback_ts_ns
+    if use_event_timestamp and event.get("event_time_ns") is not None:
+        try:
+            timestamp_ns = int(event["event_time_ns"])
+        except (TypeError, ValueError):
+            pass
+
+    line = _line_builder(measurement).time_ns(timestamp_ns)
+    for column, event_key in QUAKE_FLOAT_COLUMN_MAP.items():
+        value = event.get(event_key)
+        if value is None:
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(numeric):
+            line.float64_field(column, numeric)
+
+    for column, event_key in QUAKE_STRING_COLUMN_MAP.items():
+        value = event.get(event_key)
+        if value is not None:
+            line.string_field(column, _safe_string(value))
+
+    influxdb3_local.write(line)
+    return True
+
+
+
+def process_scheduled_call(
+    influxdb3_local,
+    call_time: datetime,
+    args: Optional[Dict[str, Any]] = None,
+) -> None:
+    task_id = str(uuid.uuid4())
+
+    global _ENABLE_FULL_LOGGING
+    _ENABLE_FULL_LOGGING = _parse_bool((args or {}).get("enable_full_logging"), False)
+
+    args = args or {}
+    source_type = _safe_string(args.get("source_type", "http")).lower() or "http"
+    if source_type not in {"http", "influxdb_table"}:
+        source_type = "http"
+
+    source_url = _safe_string(args.get("source_url"))
+    source_format = _safe_string(args.get("source_format", "usgs_geojson")).lower() or "usgs_geojson"
+    if source_format not in {"usgs_geojson", "flat_json"}:
+        source_format = "usgs_geojson"
+
+    feed = _safe_string(args.get("feed", "all_hour"))
+    if feed not in FEED_URLS:
+        feed = "all_hour"
+
+    source_table = _safe_string(args.get("source_table", "quake")) or "quake"
+    source_query = _safe_string(args.get("source_query"))
+    lookback_minutes = max(1, _parse_int(args.get("lookback_minutes"), 15))
+
+    source = source_url if source_url else feed
+    if source_type == "influxdb_table":
+        source = source_query if source_query else source_table
+
+    measurement = _safe_string(args.get("measurement", "earthquakes")) or "earthquakes"
+    write_quake_schema = _parse_bool(args.get("write_quake_schema"), False)
+    min_magnitude = _parse_float(args.get("min_magnitude"), 0.0)
+    max_events = max(1, _parse_int(args.get("max_events"), 250))
+    use_event_timestamp = _parse_bool(args.get("use_event_timestamp"), True)
+    skip_unchanged = _parse_bool(args.get("skip_unchanged"), True)
+    user_agent = _safe_string(args.get("user_agent", "InfluxDB3-Earthquake-Plugin/1.0")) or "InfluxDB3-Earthquake-Plugin/1.0"
+
+    now_ns = int(call_time.replace(tzinfo=timezone.utc).timestamp() * 1_000_000_000)
+    cache_key = f"earthquake_sampler:last_update_marker:{source_type}:{source}:{source_format}:{measurement}"
+
+    items: List[Dict[str, Any]] = []
+    if source_type == "influxdb_table":
+        try:
+            items = _fetch_table_rows(
+                influxdb3_local=influxdb3_local,
+                source_table=source_table,
+                max_events=max_events,
+                lookback_minutes=lookback_minutes,
+                source_query=source_query,
+            )
+            source_format = "flat_json"
+        except Exception as e:
+            influxdb3_local.error(f"[{task_id}] Query error while reading source table '{source_table}': {_exc(e)}")
+            return
+    else:
+        url = source_url if source_url else FEED_URLS[feed]
+        try:
+            payload = _fetch_payload(url, user_agent)
+        except HTTPError as e:
+            influxdb3_local.error(f"[{task_id}] HTTP error while fetching source '{source}': {_exc(e)}")
+            return
+        except URLError as e:
+            influxdb3_local.error(f"[{task_id}] Network error while fetching source '{source}': {_exc(e)}")
+            return
+        except json.JSONDecodeError as e:
+            influxdb3_local.error(f"[{task_id}] Invalid JSON from source '{source}': {_exc(e)}")
+            return
+        except Exception as e:
+            influxdb3_local.error(f"[{task_id}] Unexpected fetch error: {_exc(e)}")
+            return
+
+        items = _extract_events(payload, source_format)
+
+    if not items:
+        influxdb3_local.warn(f"[{task_id}] No events found for source_type={source_type} source_format={source_format}")
+        return
+
+    normalized = [_normalize_event(item, source_format) for item in items]
+
+    last_seen_marker = influxdb3_local.cache.get(cache_key)
+    try:
+        last_seen_marker = int(last_seen_marker) if last_seen_marker is not None else None
+    except (TypeError, ValueError):
+        last_seen_marker = None
+
+    fetched = 0
+    written = 0
+    skipped = 0
+    max_marker_this_run: Optional[int] = last_seen_marker
+
+    normalized.sort(key=_to_update_marker_ms, reverse=True)
+
+    for event in normalized:
+        if fetched >= max_events:
+            break
+        fetched += 1
+
+        mag = event.get("magnitude")
+        try:
+            magnitude = float(mag) if mag is not None else None
+        except (TypeError, ValueError):
+            magnitude = None
+
+        if magnitude is None or magnitude < min_magnitude:
+            skipped += 1
+            continue
+
+        marker = _to_update_marker_ms(event)
+        if skip_unchanged and last_seen_marker is not None and marker <= last_seen_marker:
+            skipped += 1
+            continue
+
+        try:
+            if write_quake_schema:
+                did_write = _write_quake_event(
+                    influxdb3_local=influxdb3_local,
+                    measurement=measurement,
+                    event=event,
+                    fallback_ts_ns=now_ns,
+                    use_event_timestamp=use_event_timestamp,
+                )
+            else:
+                did_write = _write_event(
+                    influxdb3_local=influxdb3_local,
+                    measurement=measurement,
+                    event=event,
+                    fallback_ts_ns=now_ns,
+                    use_event_timestamp=use_event_timestamp,
+                )
+            if did_write:
+                written += 1
+                if max_marker_this_run is None or marker > max_marker_this_run:
+                    max_marker_this_run = marker
+        except Exception as e:
+            skipped += 1
+            influxdb3_local.error(f"[{task_id}] Failed to write earthquake event: {_exc(e)}")
+
+    if max_marker_this_run is not None:
+        influxdb3_local.cache.put(cache_key, max_marker_this_run, ttl=None)
+
+    influxdb3_local.info(
+        f"[{task_id}] Earthquake sampler complete: "
+        f"source={source}, format={source_format}, fetched={fetched}, "
+        f"written={written}, skipped={skipped}, measurement={measurement}, "
+        f"min_magnitude={min_magnitude}"
+    )

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -461,7 +461,9 @@ def _write_event(
     line.string_field("location_source", _safe_string(event.get("location_source")))
     line.string_field("mag_source", _safe_string(event.get("mag_source")))
 
-    influxdb3_local.write(line)
+    # Buffered write() only flushes after the trigger returns, so a failed
+    # write could never be caught or counted here; write_sync raises inline.
+    influxdb3_local.write_sync(line, no_sync=True)
     return True
 
 
@@ -524,7 +526,7 @@ def _write_quake_event(
         if value is not None:
             line.string_field(column, _safe_string(value))
 
-    influxdb3_local.write(line)
+    influxdb3_local.write_sync(line, no_sync=True)
     return True
 
 

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -283,8 +283,9 @@ def _fetch_table_rows(
         query = source_query
     else:
         safe_lookback = max(1, int(lookback_minutes))
+        safe_table = source_table.replace('"', '""')
         query = (
-            f'SELECT * FROM "{source_table}" '
+            f'SELECT * FROM "{safe_table}" '
             f"WHERE time >= now() - INTERVAL '{safe_lookback} minutes' "
             f"ORDER BY time DESC "
             f"LIMIT {max_events}"

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -403,7 +403,6 @@ def _write_event(
             pass
 
     line = _line_builder(measurement).time_ns(timestamp_ns)
-    line.tag("event_id", _safe_tag(event.get("event_id"), "unknown"))
     line.tag("event_type", _safe_tag(event.get("event_type"), "earthquake"))
     line.tag("status", _safe_tag(event.get("status"), "unknown"))
     line.tag("alert", _safe_tag(event.get("alert"), "none"))
@@ -455,6 +454,7 @@ def _write_event(
         except (TypeError, ValueError):
             pass
 
+    line.string_field("event_id", _safe_string(event.get("event_id")))
     line.string_field("place", _safe_string(event.get("place")))
     line.string_field("title", _safe_string(event.get("title")))
     line.string_field("url", _safe_string(event.get("url")))

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -108,13 +108,12 @@ from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 
-def _line_builder(measurement: str):
-    import builtins
-
-    builder_cls = getattr(builtins, "LineBuilder", None)
-    if builder_cls is None:
-        raise RuntimeError("LineBuilder is not available in plugin runtime")
-    return builder_cls(measurement)
+# At server runtime LineBuilder is injected as a builtin. In test environments
+# pytest patches this module-level name to a vendored copy.
+try:
+    LineBuilder  # type: ignore  # noqa: F821
+except NameError:
+    LineBuilder = None  # placeholder for test patching
 
 
 _ENABLE_FULL_LOGGING: bool = True
@@ -425,7 +424,7 @@ def _write_event(
 ) -> bool:
     timestamp_ns = _event_timestamp_ns(event, fallback_ts_ns, use_event_timestamp)
 
-    line = _line_builder(measurement).time_ns(timestamp_ns)
+    line = LineBuilder(measurement).time_ns(timestamp_ns)
     line.tag("event_type", _safe_tag(event.get("event_type"), "earthquake"))
     line.tag("status", _safe_tag(event.get("status"), "unknown"))
     line.tag("alert", _safe_tag(event.get("alert"), "none"))
@@ -529,7 +528,7 @@ def _write_quake_event(
     """Write a normalized USGS event to a table using only the canonical quake schema."""
     timestamp_ns = _event_timestamp_ns(event, fallback_ts_ns, use_event_timestamp)
 
-    line = _line_builder(measurement).time_ns(timestamp_ns)
+    line = LineBuilder(measurement).time_ns(timestamp_ns)
     for column, event_key in QUAKE_FLOAT_COLUMN_MAP.items():
         value = event.get(event_key)
         if value is None:

--- a/influxdata/earthquake_sampler/earthquake_sampler.py
+++ b/influxdata/earthquake_sampler/earthquake_sampler.py
@@ -322,12 +322,8 @@ def _normalize_usgs_feature(feature: Dict[str, Any]) -> Dict[str, Any]:
         "place": properties.get("place"),
         "title": properties.get("title"),
         "url": properties.get("url"),
-        "depth_error": properties.get("depthError"),
-        "horizontal_error": properties.get("horizontalError"),
-        "mag_error": properties.get("magError"),
-        "mag_nst": properties.get("magNst"),
-        "location_source": properties.get("locationSource"),
-        "mag_source": properties.get("magSource"),
+        # depthError/horizontalError/magError/magNst/locationSource/magSource
+        # exist only in the USGS CSV feeds, never in GeoJSON properties.
     }
 
 
@@ -458,8 +454,10 @@ def _write_event(
     line.string_field("place", _safe_string(event.get("place")))
     line.string_field("title", _safe_string(event.get("title")))
     line.string_field("url", _safe_string(event.get("url")))
-    line.string_field("location_source", _safe_string(event.get("location_source")))
-    line.string_field("mag_source", _safe_string(event.get("mag_source")))
+    for field_name in ("location_source", "mag_source"):
+        raw = event.get(field_name)
+        if raw is not None:
+            line.string_field(field_name, _safe_string(raw))
 
     # Buffered write() only flushes after the trigger returns, so a failed
     # write could never be caught or counted here; write_sync raises inline.

--- a/influxdata/earthquake_sampler/earthquake_sampler_config_scheduler.toml
+++ b/influxdata/earthquake_sampler/earthquake_sampler_config_scheduler.toml
@@ -1,0 +1,65 @@
+# Earthquake Sampler plugin configuration for a scheduled trigger.
+# Use via the config_file_path trigger argument (path relative to PLUGIN_DIR).
+# Values set here override the inline --trigger-arguments.
+
+########## Required ##########
+# None. The defaults ingest the USGS all_hour feed into the `earthquakes`
+# measurement, so every line below is commented out — uncomment what you need.
+
+########## Source ##########
+# USGS GeoJSON feed key: all, significant, 4.5, 2.5 or 1.0, combined with
+# _hour, _day, _week or _month. Default: "all_hour".
+#feed = "all_day"
+# Data source: http (default) fetches `feed` or `source_url`; influxdb_table
+# queries an existing table in the trigger database.
+#source_type = "influxdb_table"
+# Custom JSON endpoint, http or https only. Overrides `feed`.
+#source_url = "https://example.com/earthquakes.json"
+# Parser for HTTP sources: usgs_geojson (default) or flat_json, the latter for
+# records like {id, latitude, longitude, mag, time, ...}.
+#source_format = "flat_json"
+# Source table when source_type = "influxdb_table". Default: "quake".
+#source_table = "quake"
+# SQL override for influxdb_table mode; disables watermark paging and the
+# source-table existence check. A query containing commas can only be given
+# here, not through --trigger-arguments. The single-quoted TOML string keeps
+# the double quotes that case-sensitive column names require.
+#source_query = 'SELECT time, id, mag, depth, "magType", net, updated FROM quake ORDER BY time DESC LIMIT 500'
+# Initial lookback window for influxdb_table mode, in minutes, at least 1.
+# Later runs page forward from the cached fetch watermark. Default: 15.
+#lookback_minutes = 60
+
+########## Destination ##########
+# Destination measurement. Default: "earthquakes".
+#measurement = "earthquakes"
+# Write using the canonical quake table's column names: no tags, every numeric
+# column as float64. Use with measurement = "quake". Default: false.
+#write_quake_schema = true
+# Use the event time as the point timestamp; false uses the trigger execution
+# time. Forced true when write_quake_schema = true. Default: true.
+#use_event_timestamp = true
+
+########## Filtering ##########
+# Minimum magnitude. Omit to ingest everything, including negative-magnitude
+# microseisms and events with no magnitude at all. Default: no filtering.
+#min_magnitude = 2.5
+# Maximum events written per run, at least 1. Events deferred by the cap stay
+# uncached and are written on a later run. Default: 250.
+#max_events = 250
+# Skip events whose update marker is not newer than the last written copy of
+# the same event. Default: true.
+#skip_unchanged = true
+
+########## Misc ##########
+# User-Agent header for HTTP requests.
+#user_agent = "InfluxDB3-Earthquake-Plugin/1.0"
+# Log full exception messages instead of only exception types. Default: false.
+#enable_full_logging = false
+
+###### Example: create a trigger using this config ######
+# influxdb3 create trigger \
+#   --database [YOUR_DATABASE] \
+#   --path earthquake_sampler.py \
+#   --trigger-spec "every:[DURATION e.g. 2m, 5m, 1h]" \
+#   --trigger-arguments config_file_path=earthquake_sampler_config_scheduler.toml \
+#   earthquake_sampler_trigger

--- a/influxdata/earthquake_sampler/manifest.toml
+++ b/influxdata/earthquake_sampler/manifest.toml
@@ -16,3 +16,4 @@ exclude = [
 
 [dependencies]
 database_version = ">=3.8.2"
+python = ["influxdata-plugin-utils>=0.3.0"]

--- a/influxdata/earthquake_sampler/manifest.toml
+++ b/influxdata/earthquake_sampler/manifest.toml
@@ -15,4 +15,4 @@ exclude = [
 ]
 
 [dependencies]
-database_version = ">=3.0.0"
+database_version = ">=3.8.2"

--- a/influxdata/earthquake_sampler/manifest.toml
+++ b/influxdata/earthquake_sampler/manifest.toml
@@ -1,0 +1,18 @@
+manifest_schema_version = "1.2"
+
+[plugin]
+name = "earthquake_sampler"
+version = "0.1.0"
+description = "Ingests USGS earthquake events on a schedule and writes normalized records for dashboards and alerting, with optional canonical quake-schema output."
+triggers = ["process_scheduled_call"]
+homepage = "https://www.influxdata.com/"
+repository = "https://github.com/influxdata/influxdb3_plugins/tree/main/influxdata/earthquake_sampler"
+documentation = "https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/earthquake_sampler/README.md"
+exclude = [
+  ".git/", ".venv/", "__pycache__/", "*.pyc", "tests/**",
+  ".claude/", ".vscode/", ".idea/", ".DS_Store",
+  "*.py", "!earthquake_sampler.py",
+]
+
+[dependencies]
+database_version = ">=3.0.0"

--- a/influxdata/earthquake_sampler/requirements.txt
+++ b/influxdata/earthquake_sampler/requirements.txt
@@ -1,0 +1,1 @@
+influxdata-plugin-utils>=0.3.0

--- a/influxdata/library/plugin_library.json
+++ b/influxdata/library/plugin_library.json
@@ -1,7 +1,7 @@
 {
     "plugin_library": {
         "version": "1.0.0",
-        "last_updated": "2026-08-20T00:00:00+00:00",
+        "last_updated": "2026-08-21T00:00:00+00:00",
         "plugins": [
             {
                 "name": "Downsampler",
@@ -403,7 +403,7 @@
                 "docs_file_link": "https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/earthquake_sampler/README.md",
                 "required_plugins": [],
                 "required_libraries": [],
-                "last_update": "2026-08-20",
+                "last_update": "2026-08-21",
                 "trigger_types_supported": ["scheduler"]
             }
         ]

--- a/influxdata/library/plugin_library.json
+++ b/influxdata/library/plugin_library.json
@@ -1,7 +1,7 @@
 {
     "plugin_library": {
         "version": "1.0.0",
-        "last_updated": "2026-07-14T00:00:00+00:00",
+        "last_updated": "2026-08-20T00:00:00+00:00",
         "plugins": [
             {
                 "name": "Downsampler",
@@ -394,6 +394,17 @@
                 "required_libraries": ["influxdb3-python"],
                 "last_update": "2026-06-24",
                 "trigger_types_supported": ["scheduler", "data_writes"]
+            },
+            {
+                "name": "Earthquake Sampler",
+                "path": "influxdata/earthquake_sampler/earthquake_sampler.py",
+                "description": "[BETA] Ingests USGS earthquake events on a schedule and writes normalized records for dashboards and alerting, with optional canonical quake-schema output.",
+                "author": "InfluxData",
+                "docs_file_link": "https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/earthquake_sampler/README.md",
+                "required_plugins": [],
+                "required_libraries": [],
+                "last_update": "2026-08-20",
+                "trigger_types_supported": ["scheduler"]
             }
         ]
     }

--- a/influxdata/library/plugin_library.json
+++ b/influxdata/library/plugin_library.json
@@ -402,8 +402,8 @@
                 "author": "InfluxData",
                 "docs_file_link": "https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/earthquake_sampler/README.md",
                 "required_plugins": [],
-                "required_libraries": [],
-                "last_update": "2026-08-21",
+                "required_libraries": ["influxdata-plugin-utils>=0.3.0"],
+                "last_update": "2026-08-22",
                 "trigger_types_supported": ["scheduler"]
             }
         ]


### PR DESCRIPTION
## Summary
- Adds a new scheduled plugin: `influxdata/earthquake_sampler/earthquake_sampler.py`
- Supports USGS GeoJSON ingestion and writes normalized earthquake points for dashboards and alerting
- Adds optional canonical `quake` schema output mode (`write_quake_schema=true`) for direct writes into existing `quake` tables
- Adds plugin docs: `influxdata/earthquake_sampler/README.md`
- Registers plugin in `influxdata/library/plugin_library.json`

## Validation
- `python3 -m py_compile influxdata/earthquake_sampler/earthquake_sampler.py`
- `python3 -m json.tool influxdata/library/plugin_library.json`
