### PR TITLE
nori_regression: point the model list at Synthefy's docs instead of duplicating it

### DIFF
--- a/influxdata/nori_regression/README.md
+++ b/influxdata/nori_regression/README.md
@@ -107,7 +107,7 @@ because every string form splits on whitespace. Name such a column from a TOML a
 | `max_predict_rows` | integer | `5000` | Cap on rows predicted per run; the most recent rows are kept and the rest wait for a later run. |
 | `max_read_rows` | integer | `50000` | Ceiling on rows read from InfluxDB in one run, applied as a `LIMIT` on the query. The most recent rows are read, and a truncated read is logged with a warning. This bounds the plugin's memory: a row costs roughly 0.7 KB while it is held, so the default is about 35 MB. |
 | `predict_batch_size` | integer | `1000` | Rows per gateway call. Each batch re-sends the training context and is billed separately, so a larger value costs less. |
-| `request_timeout` | string | `300s` | Timeout for one gateway call. A cold start has been measured at 60-130 seconds, so keep this well above that. |
+| `request_timeout` | string | `300s` | Timeout for one gateway call. A model that has scaled to zero cold-starts on the first request, measured between roughly one and four minutes depending on the variant, so keep this well above the warm response time. |
 | `max_retries` | integer | `3` | Maximum attempts per gateway call and per write. `1` disables retry. |
 | `config_file_path` | string | *(none)* | Path to a TOML file supplying every parameter, relative to `PLUGIN_DIR`. Cannot be combined with other inline arguments or a request body. |
 
@@ -414,15 +414,15 @@ ORDER BY 1 DESC
 
 ## Supported models
 
-The `model` argument is the Nori gateway slug your API key is granted:
+The `model` argument is the Nori gateway slug your API key is granted. The plugin defaults to
+`synthefy/nori-30m`.
 
-| Slug | Parameters | Notes |
-|---|---|---|
-| `synthefy/nori-30m` | ~29M | The default, and the variant Synthefy's own documentation recommends. Priced higher and slower to cold-start (measured at ~125s). |
-| `synthefy/nori-6m` | ~6M | Cheaper per request and faster to cold-start (measured at ~69s). |
+Synthefy publishes the current models, their sizes and their slugs at
+[docs.synthefy.com/nori/quickstart#models](https://docs.synthefy.com/nori/quickstart#models). That list is the authoritative one:
+it changes when Synthefy releases a variant, and a slug not on it will not route.
 
-Which one predicts better depends on your data; try both with `dry_run=true` before committing a
-schedule to one.
+Which model predicts better depends on your data, and the larger ones cost more per request and
+take longer to cold-start. Try a couple with `dry_run=true` before committing a schedule to one.
 
 The bare `synthefy/nori` slug has been retired and no longer routes; the plugin rejects it with a
 pointed message rather than letting the gateway answer `404`. One API key from the
@@ -526,9 +526,9 @@ names `time`/`y`.
 
 #### Cold-start latency and timeouts
 
-The models scale to zero, so the first request after an idle period is slow: about 69 seconds for
-`synthefy/nori-6m` and 125 seconds for `synthefy/nori-30m` in measurement, and it can return a
-`503` or a non-JSON body from the fronting proxy once.
+The models scale to zero, so the first request after an idle period is slow: measurements have
+ranged from roughly one minute to nearly four, with the larger variants slower, and it can return
+a `503` or a non-JSON body from the fronting proxy once.
 
 **Solution:** the default `request_timeout` of `300s` and `max_retries` of `3` are set to absorb
 this; a `503`, a `429` and a connection error are retried with backoff. A read timeout is **not**

--- a/influxdata/nori_regression/nori_regression.py
+++ b/influxdata/nori_regression/nori_regression.py
@@ -9,7 +9,7 @@
         {"name": "start_time", "example": "2026-01-01T00:00:00Z", "description": "ISO start of a fixed window instead of a trailing one. With skip_existing left on, a schedule over a fixed window backfills and then stops calling the gateway.", "required": false},
         {"name": "end_time", "example": "2026-02-01T00:00:00Z", "description": "ISO end of a fixed window. Given alone, the window starts one `window` earlier.", "required": false},
         {"name": "tags", "example": "site:A", "description": "Filter to a single series. Format: key:val key2:val2 (space-separated pairs, single value per key). A token without ':' is rejected. Required if the window holds more than one series.", "required": false},
-        {"name": "model", "example": "synthefy/nori-30m", "description": "The Nori gateway slug to call. Current slugs: synthefy/nori-30m (default, ~29M params) and synthefy/nori-6m (cheaper and faster to cold-start). The bare 'synthefy/nori' slug is retired. Your API key must be granted the slug.", "required": false},
+        {"name": "model", "example": "synthefy/nori-30m", "description": "The Nori gateway slug to call, defaulting to synthefy/nori-30m. The current list of models and their slugs is at https://docs.synthefy.com/nori/quickstart#models. The bare 'synthefy/nori' slug is retired. Your API key must be granted the slug.", "required": false},
         {"name": "output_measurement", "example": "sensors_regressed", "description": "Where to write predictions. Default: <measurement>_regressed.", "required": false},
         {"name": "target_database", "example": "predictions", "description": "Write predictions to this database instead of the trigger's own.", "required": false},
         {"name": "dry_run", "example": "false", "description": "If true, log predictions but do not write them.", "required": false},
@@ -91,6 +91,11 @@ API_KEY_HEADER = "X-Nori-Api-Key"
 # `synthefy/nori` slug was retired and now returns 404, so it is rejected with a pointed message.
 DEFAULT_MODEL_SLUG = "synthefy/nori-30m"
 RETIRED_MODEL_SLUGS = {"synthefy/nori"}
+
+# Which models exist, and their sizes, is Synthefy's to publish and changes when they release one.
+# This plugin names only its default and points at the vendor's list, so a new variant does not
+# make the plugin's documentation wrong.
+MODEL_LIST_URL = "https://docs.synthefy.com/nori/quickstart#models"
 
 # Gateway faults worth another attempt: 408/409/425 (transient conflicts), 429 (per-key rate limit,
 # 50/min) and every 5xx (a cold start can 503, or 500 once). A 4xx outside that set is a permanent
@@ -323,8 +328,8 @@ def _normalize_config(cfg) -> dict:
     model = str(cfg.get("model") or DEFAULT_MODEL_SLUG).strip()
     if model in RETIRED_MODEL_SLUGS:
         raise ConfigError(
-            f"model slug {model!r} is retired and no longer routes. Use 'synthefy/nori-30m' "
-            f"(~29M parameters) or 'synthefy/nori-6m' (cheaper, faster cold start)."
+            f"model slug {model!r} is retired and no longer routes. Use {DEFAULT_MODEL_SLUG!r} "
+            f"or another current slug, listed at {MODEL_LIST_URL}."
         )
 
     try:

--- a/influxdata/nori_regression/nori_regression_config_scheduler.toml
+++ b/influxdata/nori_regression/nori_regression_config_scheduler.toml
@@ -24,8 +24,9 @@ feature_fields = ["temp", "humidity"]
 # Filter to a single series. A run must resolve to one series; the plugin fails if the window
 # holds more. Default: no filter.
 #tags = { site = "A" }
-# Nori gateway slug. "synthefy/nori-30m" (default, ~29M parameters) or "synthefy/nori-6m"
-# (cheaper, faster cold start). The bare "synthefy/nori" slug is retired.
+# Nori gateway slug. Defaults to "synthefy/nori-30m"; the current models and their slugs are
+# listed at https://docs.synthefy.com/nori/quickstart#models
+# The bare "synthefy/nori" slug is retired.
 #model = "synthefy/nori-30m"
 # Measurement to write predictions to. Default: "<measurement>_regressed".
 #output_measurement = "sensors_regressed"


### PR DESCRIPTION
## What

The plugin kept its own list of Nori model slugs in four places: the README's "Supported models" table, the `model` argument's help text, the retired-slug error message, and the commented TOML config. Each is now a pointer to Synthefy's published list at [docs.synthefy.com/nori/quickstart#models](https://docs.synthefy.com/nori/quickstart#models).

The plugin still names its own default (`synthefy/nori-30m`), because that is the plugin's behaviour rather than the vendor's catalogue.

## Why

The copies were already stale. They list `synthefy/nori-30m` and `synthefy/nori-6m` only, while Synthefy currently publishes four entries, including `synthefy/nori-100m` and an API-only `synthefy/nori-30m-thinking-medium`. A user reading this README would not know the larger model exists.

Which models exist is not something this plugin can keep correct: it changes when Synthefy releases a variant, with no signal to this repository. Pointing at the vendor's list removes that failure mode instead of refreshing it once.

## Also in this change

The per-slug cold-start figures ("about 69 seconds for nori-6m and 125 seconds for nori-30m") are replaced by a range. They were measured against two specific variants, and a cold start has since been observed at close to four minutes, so a precise pair of numbers reads as more of a guarantee than it is. The `request_timeout` default of `300s` is unchanged and still absorbs it.

## Testing

```
pytest influxdata/nori_regression/test_nori_regression.py
190 passed
```

The retired-slug error was rendered to confirm the new interpolation:

```
model slug 'synthefy/nori' is retired and no longer routes. Use 'synthefy/nori-30m' or
another current slug, listed at https://docs.synthefy.com/nori/quickstart#models.
```

## Note

This is independent of #154, which renames the plugin's API key environment variable. Both touch `README.md` but in different sections, so they can merge in either order.
