### PR TITLE
feat: add ITOC360 notifier plugin

### DIFF
--- a/itoc360/itoc360_notifier/README.md
+++ b/itoc360/itoc360_notifier/README.md
@@ -1,0 +1,131 @@
+# ITOC360 Notifier Plugin
+
+Evaluates a threshold check on a scheduled interval and sends alert and resolve events to
+[ITOC360](https://itoc360.com/), an on-call and incident management platform. Each tag
+combination is tracked separately, so one trigger can watch many hosts or regions and each
+one opens and closes its own incident.
+
+## Prerequisites
+
+- InfluxDB 3 Core or Enterprise with the Processing Engine enabled
+- An ITOC360 account with an InfluxDB integration source, which provides the endpoint URL
+  and source token
+
+## Installation
+
+1. Copy the plugin into your plugin directory:
+
+   ```bash
+   influxdb3 install plugin gh:itoc360/itoc360_notifier/itoc360_notifier.py
+   ```
+
+2. Install the Python dependency:
+
+   ```bash
+   influxdb3 install package requests
+   ```
+
+3. Create the trigger:
+
+   ```bash
+   influxdb3 create trigger \
+     --database mydb \
+     --plugin-filename itoc360_notifier.py \
+     --trigger-spec "every:1m" \
+     --trigger-arguments measurement=cpu,field=usage_percent,check_name="CPU Threshold",window=5min,crit_threshold=90,warn_threshold=75,group_by_tags=host.region,itoc360_url="https://api.itoc360.app/functions/v1/events?token=YOUR_SOURCE_TOKEN" \
+     cpu_threshold
+   ```
+
+4. Enable it:
+
+   ```bash
+   influxdb3 enable trigger --database mydb cpu_threshold
+   ```
+
+## Configuration
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `measurement` | yes | | Measurement (table) to evaluate |
+| `field` | yes | | Numeric field to aggregate |
+| `itoc360_url` | yes | | ITOC360 endpoint including the `token` query parameter |
+| `check_name` | yes | | Display name; also forms the check identity |
+| `window` | yes | | Look-back window, `<number><unit>` with unit `s`, `min`, `h` or `d` |
+| `crit_threshold` | yes | | Threshold raising a `crit` level alert |
+| `warn_threshold` | no | disabled | Threshold raising a `warn` level alert |
+| `operator` | no | `gt` | `gt` or `lt` |
+| `aggregation` | no | `avg` | `avg`, `max`, `min`, `sum` or `count` |
+| `group_by_tags` | no | none | Dot separated tag keys, for example `host.region` |
+| `dry_run` | no | `false` | Evaluate and log without sending |
+| `max_retries` | no | `3` | HTTP delivery attempts |
+| `request_timeout` | no | `10` | Request timeout in seconds |
+
+## Event format
+
+The plugin posts the body that the ITOC360 InfluxDB provider expects, which is the same
+schema used by InfluxDB v2 Checks and Notifications:
+
+```json
+{
+  "_check_id": "cpu_threshold:cpu:host=server-01,region=eu",
+  "_check_name": "CPU Threshold",
+  "_type": "threshold",
+  "_level": "crit",
+  "_message": "avg(usage_percent) > 90 (actual: 94.2)",
+  "_time": "2026-08-31T14:30:00Z",
+  "_source_measurement": "cpu"
+}
+```
+
+When the series returns below the threshold, the same `_check_id` is sent with
+`"_level": "ok"`, which resolves the incident in ITOC360.
+
+`_level` maps to incident priority as follows: `crit` to critical, `warn` to medium, `info`
+and `ok` to low.
+
+### Check identity
+
+`_check_id` is built as `<check_slug>:<measurement>:<sorted tag key=value list>`. ITOC360
+fingerprints the incident from this string, so it must be identical between an alert and its
+resolve. Tags are sorted for that reason, and no timestamp or measured value is included.
+
+An event is sent only when a series changes level, so a sustained breach does not re-notify
+on every interval.
+
+## Testing
+
+Validate without creating a trigger:
+
+```bash
+influxdb3 test schedule_plugin \
+  --database mydb \
+  --input-arguments measurement=cpu,field=usage_percent,check_name="CPU Threshold",window=5min,crit_threshold=90,dry_run=true,itoc360_url="https://api.itoc360.app/functions/v1/events?token=YOUR_SOURCE_TOKEN" \
+  itoc360_notifier.py
+```
+
+With `dry_run=true` the plugin logs the payload it would send instead of sending it.
+
+## Logging
+
+The plugin writes to `system.processing_engine_logs`:
+
+```bash
+influxdb3 query --database mydb \
+  "SELECT * FROM system.processing_engine_logs WHERE trigger_name = 'cpu_threshold' ORDER BY time DESC LIMIT 20"
+```
+
+The source token is stripped from every log line, since these logs are queryable by anyone
+with query access to the database.
+
+## Known limitations
+
+- Level state is held in the plugin cache, which does not survive a server restart. If a
+  series is breaching before a restart and healthy afterwards, the resolve event is not sent
+  and the incident stays open in ITOC360 until the check breaches and recovers again.
+- One field per trigger. Watch several fields by creating several triggers.
+- Retries are safe to repeat because ITOC360 deduplicates on the check identity, but a
+  delivery that fails all attempts is dropped rather than queued.
+
+## License
+
+MIT or Apache 2.0, at the user's choosing.

--- a/itoc360/itoc360_notifier/itoc360_notifier.py
+++ b/itoc360/itoc360_notifier/itoc360_notifier.py
@@ -1,0 +1,431 @@
+"""
+{
+    "plugin_type": ["scheduled"],
+    "scheduled_args_config": [
+        {
+            "name": "measurement",
+            "example": "cpu",
+            "description": "Measurement (table) to evaluate.",
+            "required": true
+        },
+        {
+            "name": "field",
+            "example": "usage_percent",
+            "description": "Numeric field to aggregate and compare against the thresholds.",
+            "required": true
+        },
+        {
+            "name": "itoc360_url",
+            "example": "https://api.itoc360.app/functions/v1/events?token=YOUR_SOURCE_TOKEN",
+            "description": "ITOC360 integration endpoint including the source token query parameter.",
+            "required": true
+        },
+        {
+            "name": "check_name",
+            "example": "CPU Threshold",
+            "description": "Human readable check name sent as _check_name and used to build _check_id.",
+            "required": true
+        },
+        {
+            "name": "window",
+            "example": "5min",
+            "description": "Look-back window for the aggregation. Format: <number><unit> where unit is s, min, h, d.",
+            "required": true
+        },
+        {
+            "name": "crit_threshold",
+            "example": "90",
+            "description": "Threshold that raises a crit level alert.",
+            "required": true
+        },
+        {
+            "name": "warn_threshold",
+            "example": "75",
+            "description": "Threshold that raises a warn level alert. Omit to disable the warn level.",
+            "required": false
+        },
+        {
+            "name": "operator",
+            "example": "gt",
+            "description": "Comparison against the thresholds: gt (greater than) or lt (less than). Defaults to gt.",
+            "required": false
+        },
+        {
+            "name": "aggregation",
+            "example": "avg",
+            "description": "Aggregation applied to the field over the window: avg, max, min, sum or count. Defaults to avg.",
+            "required": false
+        },
+        {
+            "name": "group_by_tags",
+            "example": "host.region",
+            "description": "Dot separated tag keys. Each tag combination is evaluated and deduplicated separately in ITOC360.",
+            "required": false
+        },
+        {
+            "name": "dry_run",
+            "example": "false",
+            "description": "When true, evaluate and log the payload without sending it. Defaults to false.",
+            "required": false
+        },
+        {
+            "name": "max_retries",
+            "example": "3",
+            "description": "HTTP delivery attempts before giving up. Defaults to 3.",
+            "required": false
+        },
+        {
+            "name": "request_timeout",
+            "example": "10",
+            "description": "HTTP request timeout in seconds. Defaults to 10.",
+            "required": false
+        }
+    ]
+}
+"""
+
+import time
+import uuid
+from datetime import datetime, timezone
+
+import requests
+
+# Levels understood by the ITOC360 InfluxDB provider. The provider treats "ok"
+# as a RESOLVE and every other value as an ALERT, and maps the level to a
+# priority, so these literals must not be changed or capitalised.
+LEVEL_OK = "ok"
+LEVEL_INFO = "info"
+LEVEL_WARN = "warn"
+LEVEL_CRIT = "crit"
+
+CHECK_TYPE = "threshold"
+CACHE_PREFIX = "itoc360_notifier"
+
+VALID_AGGREGATIONS = ("avg", "max", "min", "sum", "count")
+VALID_OPERATORS = {"gt": ">", "lt": "<"}
+UNIT_TO_SECONDS = {"s": 1, "min": 60, "h": 3600, "d": 86400}
+
+
+def redact_url(url: str) -> str:
+    """Strip the query string from a URL so the source token never reaches the logs.
+
+    Plugin logs are queryable through system.processing_engine_logs, so a token
+    written there would be readable by anyone with query access.
+
+    Args:
+        url: The full endpoint URL.
+
+    Returns:
+        The URL without its query string.
+    """
+    return url.split("?", 1)[0] + "?token=***"
+
+
+def parse_window(window: str) -> int:
+    """Convert a window string such as "5min" into seconds.
+
+    Args:
+        window: Window in <number><unit> form, where unit is s, min, h or d.
+
+    Returns:
+        The window length in seconds.
+
+    Raises:
+        ValueError: If the window cannot be parsed or is not positive.
+    """
+    for unit in ("min", "s", "h", "d"):
+        if window.endswith(unit):
+            amount = window[: -len(unit)].strip()
+            if not amount.isdigit() or int(amount) <= 0:
+                raise ValueError(f"Invalid window amount: {window}")
+            return int(amount) * UNIT_TO_SECONDS[unit]
+    raise ValueError(f"Invalid window unit: {window}")
+
+
+def slugify(value: str) -> str:
+    """Reduce a display name to a stable lowercase identifier fragment.
+
+    Args:
+        value: Arbitrary display text.
+
+    Returns:
+        A lowercase string containing only alphanumerics and underscores.
+    """
+    cleaned = [c.lower() if c.isalnum() else "_" for c in value.strip()]
+    return "".join(cleaned).strip("_") or "check"
+
+
+def build_check_id(check_slug: str, measurement: str, tags: dict) -> str:
+    """Build the deterministic identity that ITOC360 fingerprints on.
+
+    ITOC360 derives the alert fingerprint from md5(_check_id), so the ALERT and
+    its matching RESOLVE must produce a byte identical string. Tags are sorted
+    for that reason, and no timestamp or per-run value is included.
+
+    Args:
+        check_slug: Stable slug derived from the check name.
+        measurement: Measurement being evaluated.
+        tags: Tag key/value pairs identifying the series.
+
+    Returns:
+        A string of the form "<check_slug>:<measurement>:<k=v,k=v>".
+    """
+    tag_part = ",".join(f"{k}={v}" for k, v in sorted(tags.items()))
+    return f"{check_slug}:{measurement}:{tag_part}"
+
+
+def resolve_level(value: float, operator: str, crit: float, warn: float | None) -> str:
+    """Classify an aggregated value into an ITOC360 level.
+
+    Args:
+        value: Aggregated value for the series.
+        operator: Either "gt" or "lt".
+        crit: Threshold for the crit level.
+        warn: Threshold for the warn level, or None when disabled.
+
+    Returns:
+        One of the LEVEL_* constants.
+    """
+    breached = (lambda a, b: a > b) if operator == "gt" else (lambda a, b: a < b)
+    if breached(value, crit):
+        return LEVEL_CRIT
+    if warn is not None and breached(value, warn):
+        return LEVEL_WARN
+    return LEVEL_OK
+
+
+def build_payload(
+    check_id: str,
+    check_name: str,
+    level: str,
+    message: str,
+    measurement: str,
+) -> dict:
+    """Assemble the ITOC360 event body.
+
+    Args:
+        check_id: Deterministic series identity.
+        check_name: Human readable check name.
+        level: One of the LEVEL_* constants.
+        message: Human readable description of the current state.
+        measurement: Source measurement name.
+
+    Returns:
+        The request body expected by the ITOC360 InfluxDB provider.
+    """
+    return {
+        "_check_id": check_id,
+        "_check_name": check_name,
+        "_type": CHECK_TYPE,
+        "_level": level,
+        "_message": message,
+        "_time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "_source_measurement": measurement,
+    }
+
+
+def send_event(
+    influxdb3_local,
+    url: str,
+    payload: dict,
+    max_retries: int,
+    timeout: int,
+    task_id: str,
+) -> bool:
+    """POST one event to ITOC360, retrying with exponential backoff.
+
+    Retries are safe: ITOC360 deduplicates on md5(_check_id), so a repeated
+    delivery of the same payload collapses into the existing alert.
+
+    Args:
+        influxdb3_local: InfluxDB client instance.
+        url: ITOC360 endpoint including the source token.
+        payload: Event body.
+        max_retries: Number of attempts before giving up.
+        timeout: Per request timeout in seconds.
+        task_id: Unique identifier for this plugin run.
+
+    Returns:
+        True when ITOC360 accepted the event, otherwise False.
+    """
+    safe_url = redact_url(url)
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = requests.post(url, json=payload, timeout=timeout)
+            if 200 <= response.status_code < 300:
+                influxdb3_local.info(
+                    f"[{task_id}] Sent {payload['_level']} for {payload['_check_id']} "
+                    f"to {safe_url} (status={response.status_code})"
+                )
+                return True
+            influxdb3_local.warn(
+                f"[{task_id}] ITOC360 rejected event, attempt {attempt}/{max_retries}, "
+                f"status={response.status_code}, body={response.text[:200]}"
+            )
+        except Exception as exc:
+            influxdb3_local.error(
+                f"[{task_id}] Request error to {safe_url}, "
+                f"attempt {attempt}/{max_retries}: {exc}"
+            )
+        if attempt < max_retries:
+            time.sleep(2 ** (attempt - 1))
+    influxdb3_local.error(
+        f"[{task_id}] Giving up on {payload['_check_id']} after {max_retries} attempts"
+    )
+    return False
+
+
+def parse_config(args: dict) -> dict:
+    """Validate and normalise trigger arguments.
+
+    Args:
+        args: Raw trigger arguments.
+
+    Returns:
+        A normalised configuration dictionary.
+
+    Raises:
+        ValueError: If a required argument is missing or a value is invalid.
+    """
+    for required in ("measurement", "field", "itoc360_url", "check_name", "window",
+                     "crit_threshold"):
+        if not args.get(required):
+            raise ValueError(f"Missing required argument: {required}")
+
+    aggregation = args.get("aggregation", "avg").lower()
+    if aggregation not in VALID_AGGREGATIONS:
+        raise ValueError(f"Invalid aggregation: {aggregation}")
+
+    operator = args.get("operator", "gt").lower()
+    if operator not in VALID_OPERATORS:
+        raise ValueError(f"Invalid operator: {operator}")
+
+    warn_raw = args.get("warn_threshold")
+    tags_raw = args.get("group_by_tags", "")
+
+    return {
+        "measurement": args["measurement"],
+        "field": args["field"],
+        "itoc360_url": args["itoc360_url"],
+        "check_name": args["check_name"],
+        "check_slug": slugify(args["check_name"]),
+        "window_seconds": parse_window(args["window"]),
+        "crit_threshold": float(args["crit_threshold"]),
+        "warn_threshold": float(warn_raw) if warn_raw not in (None, "") else None,
+        "operator": operator,
+        "aggregation": aggregation,
+        "group_by_tags": [t for t in tags_raw.split(".") if t],
+        "dry_run": str(args.get("dry_run", "false")).lower() == "true",
+        "max_retries": int(args.get("max_retries", 3)),
+        "request_timeout": int(args.get("request_timeout", 10)),
+    }
+
+
+def query_series(influxdb3_local, config: dict, task_id: str) -> list[dict]:
+    """Aggregate the configured field over the window, grouped by the tag set.
+
+    Args:
+        influxdb3_local: InfluxDB client instance.
+        config: Normalised configuration.
+        task_id: Unique identifier for this plugin run.
+
+    Returns:
+        One row per tag combination, each containing the aggregated value.
+    """
+    tags = config["group_by_tags"]
+    select_tags = "".join(f'"{tag}", ' for tag in tags)
+    group_by = ("GROUP BY " + ", ".join(f'"{tag}"' for tag in tags)) if tags else ""
+    query = (
+        f'SELECT {select_tags}{config["aggregation"]}("{config["field"]}") AS agg_value '
+        f'FROM "{config["measurement"]}" '
+        f"WHERE time >= now() - INTERVAL '{config['window_seconds']} seconds' "
+        f"{group_by}"
+    )
+    influxdb3_local.info(f"[{task_id}] Query: {query}")
+    return influxdb3_local.query(query)
+
+
+def process_scheduled_call(influxdb3_local, call_time, args: dict) -> None:
+    """Evaluate the configured threshold and emit ALERT or RESOLVE events.
+
+    An event is sent only when a series changes level, so a sustained breach
+    does not re-notify on every interval. Level state is held in the plugin
+    cache; see the README for the restart limitation this implies.
+
+    Args:
+        influxdb3_local: InfluxDB client instance.
+        call_time: Scheduled invocation time supplied by the Processing Engine.
+        args: Trigger arguments.
+    """
+    task_id = str(uuid.uuid4())[:8]
+
+    try:
+        config = parse_config(args or {})
+    except (ValueError, TypeError) as exc:
+        influxdb3_local.error(f"[{task_id}] Configuration error: {exc}")
+        return
+
+    try:
+        rows = query_series(influxdb3_local, config, task_id)
+    except Exception as exc:
+        influxdb3_local.error(f"[{task_id}] Query failed: {exc}")
+        return
+
+    if not rows:
+        influxdb3_local.info(f"[{task_id}] No data in window, nothing to evaluate")
+        return
+
+    for row in rows:
+        value = row.get("agg_value")
+        if value is None:
+            continue
+
+        tags = {tag: str(row.get(tag, "")) for tag in config["group_by_tags"]}
+        check_id = build_check_id(config["check_slug"], config["measurement"], tags)
+        level = resolve_level(
+            float(value),
+            config["operator"],
+            config["crit_threshold"],
+            config["warn_threshold"],
+        )
+
+        cache_key = f"{CACHE_PREFIX}:{check_id}"
+        previous = influxdb3_local.cache.get(cache_key) or LEVEL_OK
+
+        if level == previous:
+            continue
+
+        symbol = VALID_OPERATORS[config["operator"]]
+        if level == LEVEL_OK:
+            message = (
+                f"{config['aggregation']}({config['field']}) returned to normal "
+                f"(actual: {value})"
+            )
+        else:
+            threshold = (
+                config["crit_threshold"] if level == LEVEL_CRIT
+                else config["warn_threshold"]
+            )
+            message = (
+                f"{config['aggregation']}({config['field']}) {symbol} {threshold} "
+                f"(actual: {value})"
+            )
+
+        payload = build_payload(
+            check_id, config["check_name"], level, message, config["measurement"]
+        )
+
+        if config["dry_run"]:
+            influxdb3_local.info(f"[{task_id}] dry_run, would send: {payload}")
+            influxdb3_local.cache.put(cache_key, level)
+            continue
+
+        if send_event(
+            influxdb3_local,
+            config["itoc360_url"],
+            payload,
+            config["max_retries"],
+            config["request_timeout"],
+            task_id,
+        ):
+            influxdb3_local.cache.put(cache_key, level)

--- a/itoc360/itoc360_notifier/manifest.toml
+++ b/itoc360/itoc360_notifier/manifest.toml
@@ -1,0 +1,19 @@
+manifest_schema_version = "1.3"
+
+[plugin]
+name = "itoc360_notifier"
+version = "0.1.0"
+description = "Evaluates threshold checks on a scheduled interval and sends ALERT and RESOLVE events to ITOC360 incident management. Emits a deterministic check identity per tag combination so ITOC360 deduplicates and auto-resolves alerts correctly."
+triggers = ["process_scheduled_call"]
+homepage = "https://itoc360.com/"
+repository = "https://github.com/influxdata/influxdb3_plugins/tree/main/itoc360/itoc360_notifier"
+documentation = "https://github.com/influxdata/influxdb3_plugins/blob/main/itoc360/itoc360_notifier/README.md"
+exclude = [
+  ".git/", ".venv/", "__pycache__/", "*.pyc", "tests/**",
+  ".claude/", ".vscode/", ".idea/", ".DS_Store",
+  "*.py", "!itoc360_notifier.py",
+]
+
+[dependencies]
+database_version = ">=3.0.0"
+python = ["requests"]

--- a/itoc360/itoc360_notifier/requirements.txt
+++ b/itoc360/itoc360_notifier/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/itoc360/itoc360_notifier/test_itoc360_notifier.py
+++ b/itoc360/itoc360_notifier/test_itoc360_notifier.py
@@ -1,0 +1,86 @@
+import importlib.util
+from pathlib import Path
+
+
+PLUGIN_PATH = Path(__file__).with_name("itoc360_notifier.py")
+
+spec = importlib.util.spec_from_file_location("itoc360_notifier", PLUGIN_PATH)
+plugin = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(plugin)
+
+
+def test_build_check_id_is_deterministic():
+    first = plugin.build_check_id(
+        "cpu_threshold",
+        "cpu",
+        {"region": "eu", "host": "server01"},
+    )
+
+    second = plugin.build_check_id(
+        "cpu_threshold",
+        "cpu",
+        {"host": "server01", "region": "eu"},
+    )
+
+    assert first == second
+    assert first == "cpu_threshold:cpu:host=server01,region=eu"
+
+
+def test_check_id_does_not_include_runtime_values():
+    check_id = plugin.build_check_id(
+        "cpu_threshold",
+        "cpu",
+        {"host": "server01", "region": "eu"},
+    )
+
+    assert "95" not in check_id
+    assert "2026" not in check_id
+
+
+def test_resolve_level_greater_than():
+    assert plugin.resolve_level(95, "gt", 90, 75) == plugin.LEVEL_CRIT
+    assert plugin.resolve_level(80, "gt", 90, 75) == plugin.LEVEL_WARN
+    assert plugin.resolve_level(50, "gt", 90, 75) == plugin.LEVEL_OK
+
+
+def test_resolve_level_less_than():
+    assert plugin.resolve_level(5, "lt", 10, 20) == plugin.LEVEL_CRIT
+    assert plugin.resolve_level(15, "lt", 10, 20) == plugin.LEVEL_WARN
+    assert plugin.resolve_level(30, "lt", 10, 20) == plugin.LEVEL_OK
+
+
+def test_build_payload_matches_itoc360_contract():
+    payload = plugin.build_payload(
+        check_id="cpu_threshold:cpu:host=server01,region=eu",
+        check_name="CPU Threshold",
+        level="crit",
+        message="CPU threshold breached",
+        measurement="cpu",
+    )
+
+    assert payload["_check_id"] == "cpu_threshold:cpu:host=server01,region=eu"
+    assert payload["_check_name"] == "CPU Threshold"
+    assert payload["_type"] == "threshold"
+    assert payload["_level"] == "crit"
+    assert payload["_message"] == "CPU threshold breached"
+    assert payload["_source_measurement"] == "cpu"
+    assert "_time" in payload
+
+
+def test_redact_url_removes_token():
+    url = (
+        "https://api.itoc360.app/functions/v1/events"
+        "?token=super-secret-token"
+    )
+
+    redacted = plugin.redact_url(url)
+
+    assert "super-secret-token" not in redacted
+    assert redacted.endswith("?token=***")
+
+
+def test_parse_window():
+    assert plugin.parse_window("30s") == 30
+    assert plugin.parse_window("5min") == 300
+    assert plugin.parse_window("2h") == 7200
+    assert plugin.parse_window("1d") == 86400


### PR DESCRIPTION
## Overview

Adds an ITOC360 notifier plugin for the InfluxDB 3 Processing Engine.

The plugin runs on a schedule, evaluates a numeric field over a configurable time window, and sends structured alert and recovery events to ITOC360 for on-call alerting and incident management.

## How it works

Each monitored series receives a deterministic `_check_id` generated from the check name, measurement, and sorted tag set.

For example:

`cpu_threshold:cpu:host=server01,region=eu`

The same `_check_id` is used for both alert and recovery events, allowing ITOC360 to correlate them using the same fingerprint and automatically resolve the original alert.

The plugin sends InfluxDB-compatible levels:

- `crit` - critical alert
- `warn` - warning alert
- `info` - informational alert
- `ok` - recovery / resolve

## Why a dedicated plugin?

ITOC360 requires structured `_check_id` and `_level` fields for alert correlation and resolution.

A dedicated plugin allows the integration to generate deterministic per-series identities and send structured ALERT and RESOLVE payloads directly to ITOC360.

## Validation

Tested end-to-end with InfluxDB 3 Core 3.11.2 and an ITOC360 InfluxDB integration source.

Validated:

- Scheduled plugin execution
- Dry-run mode
- Live `crit` event delivery
- Live `ok` recovery delivery
- Same deterministic `_check_id` across ALERT and RESOLVE
- Automatic resolution of the original ITOC360 alert
- Per-series identity using sorted tags
- Source token redaction from Processing Engine logs
- HTTP retry and timeout handling
- Unit tests: 7 passed

## Documentation

ITOC360 InfluxDB integration documentation:

https://docs.itoc360.com/integrations/inbound-integrations/log-management/influxdb-integration